### PR TITLE
IPython tests; Decorator relative import fixed; Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ pip install configuronic
 ```bash
 git clone https://github.com/positronic/configuronic.git
 cd configuronic
-uv pip install -e .
+uv venv -p 3.10
+source .venv/bin/activate
+uv pip install -e .[dev]
 ```
 
 ## 🧠 Core Concepts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dev = [
     "ruff",
     "numpy",  # for examples
     "twine>=6.1.0",
-    "build>=1.2.2.post1"
+    "build>=1.2.2.post1",
+    "ipython",  # for tests
 ]
 
 [project.urls]

--- a/tests/support_package/cfg2.py
+++ b/tests/support_package/cfg2.py
@@ -7,5 +7,10 @@ a_nested_b_value1 = a_cfg_value1.override(value=b_cfg_value1)
 
 
 @cfn.config()
+def return1():
+    return 1
+
+
+@cfn.config()
 def return2():
     return 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -446,7 +446,7 @@ def test_override_with_multiple_dots_relative_path():
     assert env_obj.camera is B
 
 
-def test_override_with_dot_from_cfg_module_applies_replative_to_cfg_module():
+def test_override_with_dot_from_cfg_module_applies_relative_to_cfg_module():
     from tests.support_package.cfg import a_cfg_value1
 
     env_cfg = cfn.Config(Env, camera=a_cfg_value1)
@@ -456,7 +456,7 @@ def test_override_with_dot_from_cfg_module_applies_replative_to_cfg_module():
     assert env_obj.camera.value == 2
 
 
-def test_override_with_dot_from_copied_config_applies_replative_to_cfg_module():
+def test_override_with_dot_from_copied_config_applies_relative_to_cfg_module():
     from tests.support_package.cfg2 import a_cfg_value1_copy
 
     env_cfg = cfn.Config(Env, camera=a_cfg_value1_copy)
@@ -466,7 +466,17 @@ def test_override_with_dot_from_copied_config_applies_replative_to_cfg_module():
     assert env_obj.camera == 2
 
 
-def test_config_callable_with_dot_from_copied_config_applies_replative_to_cfg_module():
+def test_override_with_dot_decorator_config_applies_relative_to_cfg_module():
+    from tests.support_package.cfg2 import return1
+
+    env_cfg = cfn.Config(Env, camera=return1)
+
+    env_obj = env_cfg.override(camera=".return2").instantiate()
+
+    assert env_obj.camera == 2
+
+
+def test_config_callable_with_dot_from_copied_config_applies_relative_to_cfg_module():
     from tests.support_package.cfg2 import a_cfg_value1_copy
 
     env_cfg = cfn.Config(Env, camera=a_cfg_value1_copy)
@@ -476,7 +486,7 @@ def test_config_callable_with_dot_from_copied_config_applies_replative_to_cfg_mo
     assert env_obj.camera == 2
 
 
-def test_override_nesetd_value_with_dot_from_copied_config_applies_replative_to_cfg_module():
+def test_override_nesetd_value_with_dot_from_copied_config_applies_relative_to_cfg_module():
     from tests.support_package.cfg2 import a_nested_b_value1
 
     env_cfg = cfn.Config(Env, camera=a_nested_b_value1)
@@ -486,7 +496,7 @@ def test_override_nesetd_value_with_dot_from_copied_config_applies_replative_to_
     assert env_obj.camera.value.value == 2
 
 
-def test_override_with_dot_from_overriden_config_applies_replative_to_cfg_module():
+def test_override_with_dot_from_overriden_config_applies_relative_to_cfg_module():
     from tests.support_package.cfg2 import a_cfg_value1_override_value3
 
     env_cfg = cfn.Config(Env, camera=a_cfg_value1_override_value3)
@@ -823,5 +833,15 @@ def test_escape_at_sign_with_multiple_at_signs():
     assert result == '@@three_at_signs'
 
 
-if __name__ == '__main__':
+def test_config_args_kwargs_overlap_produces_error():
+    def func(a, b):
+        return a + b
+
+    func = cfn.Config(func, 1, 2, b=3)
+
+    with pytest.raises(TypeError, match=".* got multiple values for argument 'b'.*"):
+        func()
+
+
+if __name__ == "__main__":
     pytest.main()

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,0 +1,60 @@
+import pytest
+from IPython import InteractiveShell
+
+
+def test_config_class_could_be_created_in_ipython():
+    shell = InteractiveShell.instance()
+    result = shell.run_cell(
+        "import configuronic as cfn\n"
+        "def add(a, b): return a + b\n"
+        "add = cfn.Config(add, a=1, b=2)\n"
+        "assert add() == 3"
+    )
+    result.raise_error()
+
+
+def test_config_decorator_could_be_created_in_ipython():
+    shell = InteractiveShell.instance()
+    result = shell.run_cell(
+        "import configuronic as cfn\n"
+        "@cfn.config(a=1, b=2)\n"
+        "def add(a, b): return a + b\n"
+        "assert add() == 3"
+    )
+    result.raise_error()
+
+
+def test_config_relative_override_decorator_works_in_ipython():
+    shell = InteractiveShell.instance()
+    result = shell.run_cell(
+        "import configuronic as cfn\n"
+        "@cfn.config(val=1)\n"
+        "def fn(val): return val\n"
+        "def add(a, b): return a + b\n"
+        "add = cfn.Config(add, a=fn, b=2)\n"
+        "add_override = add.override(a='.fn')\n"
+    )
+    with pytest.raises(
+        AssertionError,
+        match="Config was created in an unknown module. Probably in IPython interactive shell. "
+        "Consider moving the config to a module.",
+    ):
+        result.raise_error()
+
+
+def test_config_relative_override_class_works_in_ipython():
+    shell = InteractiveShell.instance()
+    result = shell.run_cell(
+        "import configuronic as cfn\n"
+        "def fn(val): return val\n"
+        "fn = cfn.Config(fn, val=1)\n"
+        "def add(a, b): return a + b\n"
+        "add = cfn.Config(add, a=fn, b=2)\n"
+        "add_override = add.override(a='.fn')\n"
+    )
+    with pytest.raises(
+        AssertionError,
+        match="Config was created in an unknown module. Probably in IPython interactive shell. "
+        "Consider moving the config to a module.",
+    ):
+        result.raise_error()


### PR DESCRIPTION
* Fix inability to create cfn.Config or @cfn.config in IPython shell
* Fix wrong default module for configs created with decorator
* Add test to verify that overlapping args and kwargs will produce TypeError
* Updated local development section in README.md