### PR TITLE
Make Config(fn).override(**kwargs) is behave the same way as to Config(fn, **kwargs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ python train.py --message="@@starts_with_at"          # Literal string "@starts_
 python train.py --text="foo@bar"                      # No escaping needed in the middle
 ```
 
+Absolute imports could also be used in both Python decorators and classes. However, we don't suggest using them:
+
+```python
+@cfn.config(model="@torchvision.models.resnet34")
+def get_model_parameters(model: torch.nn.Module):
+    return list(model.named_parameters())
+```
+
+```python
+def get_model_parameters(model: torch.nn.Module):
+    return list(model.named_parameters())
+
+resnet_model_parameters = cfn.Config(
+    get_model_parameters,
+    model="@torchvision.models.resnet34"
+)
+```
+
 #### Relative Imports (`.`)
 Navigate relative to the current module, similar to Python's relative import syntax:
 

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -198,6 +198,11 @@ class Config:
         Stores the callable target and its arguments and keyword arguments, which
         can be overridden/instantiated later.
 
+        The args and kwargs could be strings with special syntax, which will be resolved to actual Python objects.
+        "@path.to.object" will be resolved to the object similar to "from path.to import object".
+
+        Relative imports (".path.to.object") has no meaning in the __init__ method, and will cause an error.
+
         Args:
             target: The target object to be configured.
             *args: Positional arguments to be passed to the target object.
@@ -217,6 +222,11 @@ class Config:
             >>>     return a + b
             >>> res = cfn.Config(sum, a=1, b=2).instantiate()
             >>> assert res == 3
+
+            >>> @cfn.config(status="@http.HTTPStatus.OK")
+            >>> def return_status(status):
+            >>>     return status
+            >>> assert return_status() == http.HTTPStatus.OK
         """
         assert callable(target), f'Target must be callable, got object of type {type(target)}.'
         self.target = target

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -220,7 +220,7 @@ class Config:
         """
         assert callable(target), f'Target must be callable, got object of type {type(target)}.'
         self.target = target
-        self.args = list(args)  # TODO: cover argument override with tests
+        self.args = [_resolve_value(arg) for arg in args]  # TODO: cover argument override with tests
         self.kwargs = {}
         self._override_inplace(**kwargs)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -843,5 +843,40 @@ def test_config_args_kwargs_overlap_produces_error():
         func()
 
 
-if __name__ == "__main__":
+def test_config_instantiation_string_in_decorator_resolves_properly():
+    @cfn.config(a='@tests.support_package.cfg2.return1')
+    def func(a):
+        return a
+
+    assert func.instantiate() == 1
+
+
+def test_config_instantiation_string_in_class_resolves_properly():
+    def func(a):
+        return a
+
+    func_cfg = cfn.Config(func, a='@tests.support_package.cfg2.return1')
+
+    assert func_cfg.instantiate() == 1
+
+
+def test_config_copy_with_double_at_sign_in_decorator_produces_same_config():
+    @cfn.config(a='@@some_string')
+    def func(a):
+        return a
+
+    func_copy = func.copy()
+
+    assert func_copy() == func() == '@some_string'
+
+
+def test_config_dot_string_in_decorator_produces_value_error():
+    with pytest.raises(ValueError, match='Relative import used with no default value'):
+
+        @cfn.config(a='.return1')
+        def func(a):
+            return a
+
+
+if __name__ == '__main__':
     pytest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -860,6 +860,15 @@ def test_config_instantiation_string_in_class_resolves_properly():
     assert func_cfg.instantiate() == 1
 
 
+def test_config_instantiation_string_positional_arg_in_class_resolves_properly():
+    def func(a):
+        return a
+
+    func_cfg = cfn.Config(func, '@tests.support_package.cfg2.return1')
+
+    assert func_cfg.instantiate() == 1
+
+
 def test_config_copy_with_double_at_sign_in_decorator_produces_same_config():
     @cfn.config(a='@@some_string')
     def func(a):
@@ -870,12 +879,38 @@ def test_config_copy_with_double_at_sign_in_decorator_produces_same_config():
     assert func_copy() == func() == '@some_string'
 
 
+def test_config_copy_with_double_at_sign_in_class_positional_arg_produces_same_config():
+    def func(a):
+        return a
+
+    func_cfg = cfn.Config(func, '@@some_string')
+
+    func_copy = func_cfg.copy()
+
+    assert func_copy() == func_cfg() == '@some_string'
+
 def test_config_dot_string_in_decorator_produces_value_error():
     with pytest.raises(ValueError, match='Relative import used with no default value'):
 
         @cfn.config(a='.return1')
         def func(a):
             return a
+
+
+def test_config_dot_string_in_class_produces_value_error():
+    with pytest.raises(ValueError, match='Relative import used with no default value'):
+
+        def func(x):
+            return x
+        cfn.Config(func, a='.return1')
+
+
+def test_config_dot_string_positional_arg_in_class_produces_value_error():
+    with pytest.raises(ValueError, match='Relative import used with no default value'):
+
+        def func(x):
+            return x
+        cfn.Config(func, '.return1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As was noted in issue #6 . Currently the override and __init__ behave differently with respect to "@" usage.
```
c1 = Config(fn, **kwargs)
c2 = Config(fn).override(**kwargs)
c1 != c2
```

This PR fixes this issue