### PR TITLE
Multi-script no arg cli call shows help

### DIFF
--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -80,7 +80,7 @@ def _cli_multiple_commands(commands_config: dict[str, Config]):
     def _run_and_help(_command: str = None, help: bool = False, **kwargs):
         args = sys.argv[1:]
         # Handle help flag manually to choose a proper function for fire.Fire
-        if args[0] == '--help':
+        if len(args) == 0 or args[0] == '--help':
             print('Commands:')
             for command in commands_config:
                 target_command_doc = commands_config[command].target.__doc__

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,3 +142,14 @@ def test_cli_multiple_commands_unknown_command_with_help_raises_error(capfd):
         with pytest.raises(ValueError) as e:
             cfn.cli({'func1': func1, 'func2': func2})
         assert "Command 'func3' not found. Available commands: ['func1', 'func2']" in str(e.value)
+
+
+def test_cli_multiple_commands_print_help_if_no_args_provided(capfd):
+    @cfn.config()
+    def func1(a):
+        print(f"a: {a}")
+
+    with patch('sys.argv', ['script.py']):
+        cfn.cli({'func1': func1})
+        out, err = capfd.readouterr()
+        assert "python script.py func1 --a=<REQUIRED>" in out


### PR DESCRIPTION
Added new behavior: when multi-command cli called with no args it now shows help. 

New behavior: 
```python
# content of test.py
import configuronic as cfn

@cfn.config()
def func1(a):
    print(f"a: {a}")

cfn.cli({'func1': func1})
```
```bash
$ python test.py 
Commands:
python test.py func1 --a=<REQUIRED>
```

It will also fix #20 issue.