### PR TITLE
Improved `Config` override error reporting by surfacing a contextual `ConfigError` that preserves the original failure details.

### DIFF
--- a/.github/workflows/announce-merged-pr.yaml
+++ b/.github/workflows/announce-merged-pr.yaml
@@ -1,0 +1,94 @@
+name: Announce merged PRs (main only)
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Find PR associated with this commit
+        id: find_pr
+        uses: actions/github-script@v7
+        env:
+          SHA: ${{ github.sha }}
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const sha = process.env.SHA;
+            const res = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: sha,
+            });
+            const pr = res.data.find(p => p.merged_at) || res.data[0];
+            if (!pr) {
+              core.setOutput('found', 'false');
+              return;
+            }
+            core.setOutput('found', 'true');
+            core.setOutput('num', pr.number.toString());
+            core.setOutput('title', pr.title || '');
+            core.setOutput('url', pr.html_url || '');
+            core.setOutput('body', pr.body || '');
+            core.setOutput('author', pr.user?.login || 'unknown');
+            core.setOutput('merged_by', pr.merged_by?.login || 'unknown');
+            core.setOutput('base', pr.base?.ref || 'main');
+
+      - name: Stop if no PR
+        if: steps.find_pr.outputs.found != 'true'
+        run: echo "No associated PR found for this push (likely a direct push). Skipping."
+
+      - name: Post Discord embed
+        if: steps.find_pr.outputs.found == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}  # add this secret
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.find_pr.outputs.num }}
+          PR_TITLE: ${{ steps.find_pr.outputs.title }}
+          PR_URL: ${{ steps.find_pr.outputs.url }}
+          PR_AUTHOR: ${{ steps.find_pr.outputs.author }}
+          MERGED_BY: ${{ steps.find_pr.outputs.merged_by }}
+          BASE_BRANCH: ${{ steps.find_pr.outputs.base }}
+          PR_BODY: ${{ steps.find_pr.outputs.body }}
+        run: |
+          body="${PR_BODY:-}"
+          body="${body//$'\r'/}"
+          body="${body:0:3500}"
+          merged_by="${MERGED_BY:-unknown}"
+
+          payload=$(jq -n \
+            --arg repo "$REPO" \
+            --arg num "$PR_NUM" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg body "$body" \
+            --arg author "$PR_AUTHOR" \
+            --arg base "$BASE_BRANCH" \
+            --arg merged_by "$merged_by" \
+            '{
+              username: "GitHub",
+              embeds: [{
+                title: ("PR Merged: #"+$num+" \u2013 "+$title),
+                url: $url,
+                description: $body,
+                color: 5814783,
+                fields: [
+                  { "name": "Repository", "value": $repo, "inline": true },
+                  { "name": "Author", "value": ("@" + $author), "inline": true },
+                  { "name": "Merged into", "value": ("`" + $base + "`"), "inline": true }
+                ],
+                footer: { "text": ("Merged by " + $merged_by) }
+              }]
+            }')
+
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL is empty. Did you create the secret?" >&2
+            exit 1
+          fi
+
+          curl -sS -X POST -H "Content-Type: application/json" \
+               -d "$payload" \
+               "$DISCORD_WEBHOOK_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.3] - 2025-09-25
+
+### Fixed
+- Improved Config override error reporting by surfacing a contextual `ConfigError` that preserves the original failure details.
+
+
 ## [0.2.2] - 2025-09-05
 
 ### Fixed

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -290,17 +290,22 @@ class Config:
 
     def _override_inplace(self, **overrides):
         for key, value in overrides.items():
-            key_list = key.split('.')
+            try:
+                key_list = key.split('.')
 
-            current_obj = self
+                current_obj = self
 
-            for i, key in enumerate(key_list[:-1]):
-                current_obj = _get_value(current_obj, key)
-                if current_obj is None:
-                    path_to_not_found_arg = '.'.join(key_list[: i + 1])
-                    raise ConfigError(f"Argument '{path_to_not_found_arg}' not found in config")
+                for i, key in enumerate(key_list[:-1]):
+                    current_obj = _get_value(current_obj, key)
+                    if current_obj is None:
+                        path_to_not_found_arg = '.'.join(key_list[:i + 1])
+                        raise ConfigError(
+                            f"Argument '{path_to_not_found_arg}' not found in config"
+                        )
 
-            _set_value(current_obj, key_list[-1], value)
+                _set_value(current_obj, key_list[-1], value)
+            except Exception as e:
+                raise ConfigError(f"Failed to override '{key}' with value '{value}'") from e
 
     def _set_value(self, key, value):
         default = self._get_value(key) if self._has_value(key) else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.2.2"
+version = "0.2.3"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,6 +1,8 @@
 import pytest
 from IPython import InteractiveShell
 
+import configuronic as cfn
+
 
 def test_config_class_could_be_created_in_ipython():
     shell = InteractiveShell.instance()
@@ -34,12 +36,15 @@ def test_config_relative_override_decorator_works_in_ipython():
         "add = cfn.Config(add, a=fn, b=2)\n"
         "add_override = add.override(a='.fn')\n"
     )
-    with pytest.raises(
-        AssertionError,
-        match="Config was created in an unknown module. Probably in IPython interactive shell. "
-        "Consider moving the config to a module.",
-    ):
+    with pytest.raises(cfn.ConfigError) as exc_info:
         result.raise_error()
+
+    assert isinstance(exc_info.value.__cause__, AssertionError)
+    assert (
+        "Config was created in an unknown module. Probably in IPython interactive shell. "
+        "Consider moving the config to a module."
+        in str(exc_info.value.__cause__)
+    )
 
 
 def test_config_relative_override_class_works_in_ipython():
@@ -52,9 +57,12 @@ def test_config_relative_override_class_works_in_ipython():
         "add = cfn.Config(add, a=fn, b=2)\n"
         "add_override = add.override(a='.fn')\n"
     )
-    with pytest.raises(
-        AssertionError,
-        match="Config was created in an unknown module. Probably in IPython interactive shell. "
-        "Consider moving the config to a module.",
-    ):
+    with pytest.raises(cfn.ConfigError) as exc_info:
         result.raise_error()
+
+    assert isinstance(exc_info.value.__cause__, AssertionError)
+    assert (
+        "Config was created in an unknown module. Probably in IPython interactive shell. "
+        "Consider moving the config to a module."
+        in str(exc_info.value.__cause__)
+    )


### PR DESCRIPTION
This change is intended to provide more information when command-line parsing fails