### PR TITLE
Add support for lists and dicts with config references (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Added
 - Support for passing entire lists and dictionaries containing config references from CLI and Python code. You can now use `--items='["@module.Obj1", ".Obj2"]'` or `--config='{"key": "@module.Value"}'` to override collections with config references.
-- All relative paths (`.`) in full list/dict overrides consistently resolve against the config's creator module, providing predictable behavior. Indexed overrides (e.g., `--items.0='.value'`) continue to resolve relative to the element's default.
+- Both absolute (`@`) and relative (`.`) references are resolved recursively at all nesting levels within lists and dicts, providing consistent behavior throughout nested structures.
+- All relative paths (`.`) in list/dict overrides resolve against the config (similar to standard resolution). Indexed overrides (e.g., `--items.0='.value'`) continue to resolve relative to the element's default.
 
 ### Changed
-- **Breaking:** Dot-prefixed strings in full list/dict overrides now trigger relative import resolution. To pass literal strings like `'./data'` or `'.env'`, use indexed override syntax: `--paths='["",""]' --paths.0='./data' --paths.1='.env'`.
+- **Breaking:** Dot-prefixed strings in list/dict overrides now trigger relative import resolution. To pass literal strings like `'./data'` or `'.env'`, use indexed override syntax: `--paths='["",""]' --paths.0='./data' --paths.1='.env'`.
 
 ## [0.2.3] - 2025-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.0] - 2025-10-25
+
+### Added
+- Support for passing entire lists and dictionaries containing config references from CLI and Python code. You can now use `--items='["@module.Obj1", ".Obj2"]'` or `--config='{"key": "@module.Value"}'` to override collections with config references.
+- All relative paths (`.`) in full list/dict overrides consistently resolve against the config's creator module, providing predictable behavior. Indexed overrides (e.g., `--items.0='.value'`) continue to resolve relative to the element's default.
+
+### Changed
+- **Breaking:** Dot-prefixed strings in full list/dict overrides now trigger relative import resolution. To pass literal strings like `'./data'` or `'.env'`, use indexed override syntax: `--paths='["",""]' --paths.0='./data' --paths.1='.env'`.
+
 ## [0.2.3] - 2025-09-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Without `copy()`, `.local_function` would try to resolve in `configs.base` and f
 
 ### Lists and Dictionaries
 
-Configuronic seamlessly handles nested data structures:
+Configuronic seamlessly handles nested data structures and supports config references within them:
 
 ```python
 simulation_cfg = cfn.Config(
@@ -305,11 +305,61 @@ simulation_cfg = cfn.Config(
     }
 )
 
-# Override specific items
+# Override specific items using indexed notation
 modified_sim = simulation_cfg.override(**{
     "loaders.0.camera_config.fps": 60,  # First loader's camera FPS
     "cameras.main.position": [0, 0, 2]   # Main camera position
 })
+
+# Override entire lists/dicts with config references
+from_cli = simulation_cfg.override(
+    loaders=[
+        '@my_loaders.CameraLoader',
+        '@my_loaders.ObjectLoader',
+        '.CustomLightingLoader'  # Relative to simulation_cfg's module
+    ]
+)
+```
+
+#### Lists and Dicts with Config References
+
+You can pass entire lists or dictionaries containing config references (using `@` or `.` syntax):
+
+```python
+# From CLI (we rely on fire's parsing behavior)
+python script.py --models='["@transformers.BertModel", "@transformers.GPT2Model"]'
+python script.py --cameras='{"left": "@opencv.Camera", "right": ".CustomCamera"}'
+
+# From Python code
+config = cfg.override(
+    models=['@transformers.BertModel', '@transformers.GPT2Model'],
+    datasets=['.ImageNetDataset', '.CocoDataset']
+)
+```
+
+**Important:**
+
+1. **Replacement semantics:** Overriding an entire list or dict completely replaces all previous values, including any defaults that were defined. This is assignment, not merging.
+
+2. **Relative resolution:** All relative paths (`.`) in a full list/dict override resolve against the **config**, not individual element defaults.
+
+```python
+# In file: myproject/training.py
+@cfn.config(datasets=[SomeDefaultDataset, AnotherDefault, ThirdDefault])
+def train(datasets):
+    pass
+
+# CLI: python training.py --datasets='[".LocalDataset", ".RemoteDataset"]'
+# Result:
+#   - Original 3 defaults are completely replaced by 2 new values
+#   - Both resolve to: myproject.training.LocalDataset, myproject.training.RemoteDataset
+```
+
+To pass literal strings starting with `.` (like `'./data'` or `'.env'`), use indexed override instead:
+
+```bash
+# Initialize with empty strings, then override individually
+python script.py --paths='["",""]' --paths.0='./data' --paths.1='.env'
 ```
 
 ### Configuration Inheritance

--- a/README.md
+++ b/README.md
@@ -337,11 +337,11 @@ config = cfg.override(
 )
 ```
 
-**Important:**
+**Key points:**
 
 1. **Replacement semantics:** Overriding an entire list or dict completely replaces all previous values, including any defaults that were defined. This is assignment, not merging.
 
-2. **Relative resolution:** All relative paths (`.`) in a full list/dict override resolve against the **config**, not individual element defaults.
+2. **Relative resolution:** All relative paths (`.`) in a list/dict override resolve against the **config** (similar to standard resolution). Both absolute (`@`) and relative (`.`) references work recursively at all nesting levels.
 
 ```python
 # In file: myproject/training.py
@@ -352,7 +352,11 @@ def train(datasets):
 # CLI: python training.py --datasets='[".LocalDataset", ".RemoteDataset"]'
 # Result:
 #   - Original 3 defaults are completely replaced by 2 new values
-#   - Both resolve to: myproject.training.LocalDataset, myproject.training.RemoteDataset
+#   - Both resolve relative to the config: myproject.training.LocalDataset, myproject.training.RemoteDataset
+
+# Nested collections also resolve references:
+python training.py --data='[[".Dataset1", "@other.Dataset2"], {"key": ".value"}]'
+# All references (@ and .) are resolved recursively at any depth
 ```
 
 To pass literal strings starting with `.` (like `'./data'` or `'.env'`), use indexed override instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.2.3"
+version = "0.3.0"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/support_package/cfg2.py
+++ b/tests/support_package/cfg2.py
@@ -14,3 +14,8 @@ def return1():
 @cfn.config()
 def return2():
     return 2
+
+
+@cfn.config()
+def return3():
+    return 3

--- a/tests/support_package/cfg3.py
+++ b/tests/support_package/cfg3.py
@@ -28,3 +28,9 @@ def process_items(items):
 @cfn.config(config={'key1': cfg2_return1})
 def process_config(config):
     return config
+
+
+# Simple config for testing
+@cfn.config()
+def return_items(items):
+    return items

--- a/tests/support_package/cfg3.py
+++ b/tests/support_package/cfg3.py
@@ -1,0 +1,30 @@
+import configuronic as cfn
+from tests.support_package.cfg2 import return1 as cfg2_return1
+
+
+@cfn.config()
+def func_a():
+    return 'a'
+
+
+@cfn.config()
+def func_b():
+    return 'b'
+
+
+@cfn.config()
+def func_c():
+    return 'c'
+
+
+# Config that has a list with one default from a DIFFERENT module (cfg2)
+# This proves that fallback doesn't use the default's module
+@cfn.config(items=[cfg2_return1])
+def process_items(items):
+    return items
+
+
+# Config that has a dict with one default from a DIFFERENT module (cfg2)
+@cfn.config(config={'key1': cfg2_return1})
+def process_config(config):
+    return config


### PR DESCRIPTION
## Summary

Adds support for passing lists and dictionaries containing config references (`@` and `.` syntax) from CLI and Python code.

### Resolution Behavior

- **Full override** (`--items='[".a", ".b"]'`): All relative paths resolve to config's creator module
- **Indexed override** (`--items.0='.a'`): Resolves to element's default module (existing behavior)

### Breaking Change

⚠️ Dot-prefixed strings in lists/dicts now trigger relative import resolution. 

To pass literals like `'./data'`: use indexed override `--paths='[""]' --paths.0='./data'`

### Changes

- Modified `_resolve_value()` to recursively handle lists/dicts
- Updated README.md and CHANGELOG.md
- Bumped version to 0.3.0