### PR TITLE
Fix relative import resolution when run via `python -m`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# uv
+uv.lock
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be added to the global gitignore or merged into this project gitignore.  For a PyCharm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.1] - 2026-02-06
+
+### Fixed
+- Fix relative import resolution when module is run via `python -m`. The `_creator_module.__name__` is `'__main__'` in that case, breaking relative path computation. Now uses `__spec__.name` which preserves the real module path.
+
 ## [0.3.0] - 2025-10-25
 
 ### Added

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -85,7 +85,10 @@ def _get_base_path_from_default(default: Any) -> str:
             'Config was created in an unknown module. Probably in IPython interactive shell. '
             'Consider moving the config to a module.'
         )
-        return default._creator_module.__name__ + '.' + 'stub_name'
+        module = default._creator_module
+        name = getattr(module.__spec__, 'name', None) if hasattr(module, '__spec__') else None
+        name = name or module.__name__
+        return name + '.' + 'stub_name'
     elif isinstance(default, str):
         return default.lstrip(INSTANTIATE_PREFIX)
     elif hasattr(default, '__module__') and hasattr(default, '__name__'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.3.0"
+version = "0.3.1"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/support_package/main_runner.py
+++ b/tests/support_package/main_runner.py
@@ -1,0 +1,20 @@
+import sys
+
+import configuronic as cfn
+from tests.support_package.subpkg.a import A
+
+
+def wrapper(inner):
+    return inner
+
+
+inner_cfg = cfn.Config(A, value=1)
+outer_cfg = cfn.Config(wrapper, inner=inner_cfg)
+
+if __name__ == '__main__':
+    from tests.support_package.b import B
+
+    result = outer_cfg.override(inner='..b.B').instantiate()
+    assert result is B, f'Expected class B, got {result}'
+    print('OK')
+    sys.exit(0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from enum import Enum
 
 import pytest
@@ -1185,6 +1187,7 @@ def test_list_override_with_literals():
 
 def test_dict_override_with_mixed_types():
     """Test dict with mixed value types."""
+
     @cfn.config()
     def return_config(config):
         return config
@@ -1217,6 +1220,7 @@ def test_literal_dot_prefix_strings_via_indexed_override():
     To pass literals like './data' or '.env', use indexed override or
     initialize with empty strings and override later.
     """
+
     @cfn.config(items=['', ''])
     def return_items(items):
         return items
@@ -1247,6 +1251,15 @@ def test_nested_references_resolved_at_all_depths():
     assert result[0] == 'a'  # Top-level relative resolved
     assert result[1] == [1, 'b']  # Nested absolute and relative resolved
     assert result[2] == {'abs': 2, 'rel': 'c'}  # Nested dict references resolved
+
+
+def test_relative_import_uses_spec_name_when_module_name_is_main():
+    result = subprocess.run(
+        [sys.executable, '-m', 'tests.support_package.main_runner'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f'stdout: {result.stdout}\nstderr: {result.stderr}'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- `_get_base_path_from_default` used `module.__name__` which is `'__main__'` when the module is executed with `-m`, breaking relative path computation (e.g. `..internal.droid` resolved to `internal.droid` instead of `positronic.cfg.ds.internal.droid`)
- Now prefers `module.__spec__.name` which preserves the real module path, with fallback to `__name__`
- Added `uv.lock` to `.gitignore`

## Test plan
- Added subprocess-based test that runs a module as `__main__` and verifies relative import resolution works correctly
- All 113 tests pass