### PR TITLE
Add `python -m configuronic` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] - 2026-02-16
+
+### Added
+- Support for `python -m configuronic @path.to.module.Config [--param=value ...]`. Any `Config` object on the Python path can now be run directly without a wrapper script.
+
 ## [0.3.1] - 2026-02-06
 
 ### Fixed

--- a/configuronic/__main__.py
+++ b/configuronic/__main__.py
@@ -1,0 +1,25 @@
+import sys
+
+from configuronic.cli import cli
+from configuronic.config import Config, _import_object_from_path
+
+
+def main():
+    if len(sys.argv) < 2 or not sys.argv[1].startswith('@'):
+        print('Usage: python -m configuronic @path.to.module.Config [--param=value ...]', file=sys.stderr)
+        sys.exit(1)
+
+    import_path = sys.argv[1]
+    sys.argv = [sys.argv[0]] + sys.argv[2:]
+
+    obj = _import_object_from_path(import_path)
+
+    if not isinstance(obj, Config):
+        print(f'Error: {import_path} resolved to {type(obj).__name__}, expected a Config object', file=sys.stderr)
+        sys.exit(1)
+
+    cli(obj)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.3.1"
+version = "0.4.0"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/support_package/cfg.py
+++ b/tests/support_package/cfg.py
@@ -6,3 +6,8 @@ a_cfg_value1 = cfn.Config(A, value=1)
 a_cfg_value2 = cfn.Config(A, value=2)
 b_cfg_value1 = cfn.Config(B, value=1)
 b_cfg_value2 = cfn.Config(B, value=2)
+
+
+@cfn.config(message='hello')
+def echo(message):
+    print(message)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+
+
+def run_main(*args):
+    return subprocess.run([sys.executable, '-m', 'configuronic', *args], capture_output=True, text=True)
+
+
+def test_main_resolves_and_runs_config():
+    result = run_main('@tests.support_package.cfg.echo')
+    assert result.returncode == 0
+    assert result.stdout.strip() == 'hello'
+
+
+def test_main_passes_override_params():
+    result = run_main('@tests.support_package.cfg.echo', '--message=world')
+    assert result.returncode == 0
+    assert result.stdout.strip() == 'world'
+
+
+def test_main_missing_arg_prints_usage():
+    result = run_main()
+    assert result.returncode == 1
+    assert 'Usage:' in result.stderr
+
+
+def test_main_arg_without_at_prefix_prints_usage():
+    result = run_main('tests.support_package.cfg.echo')
+    assert result.returncode == 1
+    assert 'Usage:' in result.stderr
+
+
+def test_main_invalid_import_path():
+    result = run_main('@nonexistent.module.thing')
+    assert result.returncode != 0
+
+
+def test_main_non_config_object():
+    result = run_main('@tests.support_package.b.B')
+    assert result.returncode == 1
+    assert 'expected a Config object' in result.stderr


### PR DESCRIPTION
## Summary
- Add `__main__.py` so any `Config` object on the Python path can be run directly: `python -m configuronic @path.to.module.config --param=value`
- Pops the `@`-prefixed import path, resolves it via `_import_object_from_path`, validates it's a `Config`, and passes it to `cli()`
- Version bump to 0.4.0 with changelog entry

## Test plan
- 6 new tests covering: resolve & run, CLI overrides, missing arg, no `@` prefix, invalid import path, non-Config object
- Full suite: 119 tests passing, 94.65% coverage (`__main__.py` at 100%)