### PR TITLE
Add nested command trees to `cfn.cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0] - 2026-05-31
+
+### Added
+- Nested command trees in `cfn.cli`. The dict form now accepts arbitrarily-nested dicts of `Config`s: positional args walk the tree by key until a `Config` leaf, then `--kwargs` override and instantiate it (e.g. `script.py group subcommand --param=value`). `--help` lists child commands at a group node and required args at a leaf. The previous flat `{'cmd': cfg}` form is the depth-1 special case and is unchanged.
+
 ## [0.4.0] - 2026-02-16
 
 ### Added

--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -120,17 +120,27 @@ def _cli_command_tree(tree: CommandTree):
     args = sys.argv[1:]
     node, path, rest = _walk_tree(tree, args)
     if isinstance(node, dict):
-        # A group node (root or intermediate): list its children. Reached when no
-        # positional selects a leaf — e.g. no args, a trailing ``--help``, or a
-        # bare group name.
+        # A group node (root or intermediate): list its children — but only for no
+        # args or an explicit ``--help``. An option-looking token before any leaf is
+        # selected (e.g. ``--typo``) is a mistake, not a request for help: reject it,
+        # matching the flat-dict "Command not found" behavior instead of silently
+        # printing help and exiting 0.
+        if rest and '--help' not in rest:
+            available = list(node.keys())
+            scope = f" under '{' '.join(path)}'" if path else ''
+            raise ValueError(f"Command '{rest[0]}' not found{scope}. Available commands: {available}")
         _print_group_help(node, path)
         return None
     # Config leaf: remaining args are its overrides. Handle ``--help`` ourselves so
-    # fire doesn't intercept it, then let fire parse the ``--kwargs`` (``command=rest``
-    # keeps fire from re-reading the already-consumed positional path off sys.argv).
+    # fire doesn't intercept it, but still apply any overrides first so the help
+    # reflects the overridden config (``command=`` keeps fire from re-reading the
+    # already-consumed positional path off sys.argv).
     runner = _cli_single_command(node)
     if '--help' in rest:
-        return runner(help=True)
+        overrides = [a for a in rest if a != '--help']
+        if not overrides:
+            return runner(help=True)
+        return fire.Fire(lambda **kwargs: runner(help=True, **kwargs), command=overrides)
     return fire.Fire(runner, command=rest)
 
 

--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -48,7 +48,7 @@ def get_required_args(config: Config) -> list[str]:
     return _get_required_args_recursive(config, '')
 
 
-def _cli_single_command(config: Config, is_command_first: bool = False):
+def _cli_single_command(config: Config):
     assert 'help' not in config.kwargs, "Config contains 'help' argument. This is reserved for the help flag."
 
     def _run_and_help(help: bool = False, **kwargs):
@@ -66,48 +66,82 @@ def _cli_single_command(config: Config, is_command_first: bool = False):
         else:
             return overriden_config.instantiate()
 
-    if is_command_first:
-        # HACK: Add fake first argument to a function signature so the `Fire` threat it as a positional argument
-        def _run_and_help_wrapper(_command: str=None, help: bool = False, **kwargs):
-            return _run_and_help(help, **kwargs)
-
-        return _run_and_help_wrapper
-    else:
-        return _run_and_help
+    return _run_and_help
 
 
-def _cli_multiple_commands(commands_config: dict[str, Config]):
-    def _run_and_help(_command: str = None, help: bool = False, **kwargs):
-        args = sys.argv[1:]
-        # Handle help flag manually to choose a proper function for fire.Fire
-        if len(args) == 0 or args[0] == '--help':
-            print('Commands:')
-            for command in commands_config:
-                target_command_doc = commands_config[command].target.__doc__
-                if target_command_doc:
-                    first_line_of_doc = target_command_doc.split('\n')[0]
-                    command_description = f' # {first_line_of_doc}'
-                else:
-                    command_description = ''
-                required_args = get_required_args(commands_config[command])
-                required_args_str = ' '.join([f'--{arg}=<REQUIRED>' for arg in required_args])
-                print(f'python {sys.argv[0]} {command} {required_args_str}{command_description}')
-            print()
-        elif args[0] in commands_config:
-            return _cli_single_command(commands_config[args[0]], is_command_first=True)(_command, help, **kwargs)
+# A command tree is a (possibly nested) dict whose leaves are Configs. Positional
+# args walk the tree by successive key lookups; the first option-looking token
+# (``-``-prefixed) or a Config leaf ends the walk.
+CommandTree = dict[str, 'Config | CommandTree']
+
+
+def _walk_tree(tree: CommandTree, args: list[str]) -> tuple[Config | CommandTree, list[str], list[str]]:
+    """Walk positional args down the command tree.
+
+    Returns ``(node, path, rest)`` where ``node`` is the reached tree node (a
+    ``Config`` leaf or an inner dict), ``path`` is the consumed keys, and
+    ``rest`` is the remaining (unconsumed) args — the ``--kwargs`` and ``--help``.
+    """
+    node: Config | CommandTree = tree
+    path: list[str] = []
+    i = 0
+    while isinstance(node, dict) and i < len(args) and not args[i].startswith('-'):
+        key = args[i]
+        if key not in node:
+            available = list(node.keys())
+            if path:
+                raise ValueError(f"Command '{key}' not found under '{' '.join(path)}'. Available commands: {available}")
+            raise ValueError(f"Command '{key}' not found. Available commands: {available}")
+        node = node[key]
+        path.append(key)
+        i += 1
+    return node, path, args[i:]
+
+
+def _print_group_help(node: CommandTree, path: list[str]):
+    print('Commands:')
+    prefix = (' '.join(path) + ' ') if path else ''
+    for command, child in node.items():
+        if isinstance(child, dict):
+            print(f'python {sys.argv[0]} {prefix}{command} <command> ...')
+            continue
+        target_command_doc = child.target.__doc__
+        if target_command_doc:
+            command_description = f' # {target_command_doc.split(chr(10))[0]}'
         else:
-            raise ValueError(f"Command '{args[0]}' not found. Available commands: {list(commands_config.keys())}")
+            command_description = ''
+        required_args = get_required_args(child)
+        required_args_str = ' '.join([f'--{arg}=<REQUIRED>' for arg in required_args])
+        print(f'python {sys.argv[0]} {prefix}{command} {required_args_str}{command_description}')
+    print()
 
-    fire.Fire(_run_and_help)
+
+def _cli_command_tree(tree: CommandTree):
+    args = sys.argv[1:]
+    node, path, rest = _walk_tree(tree, args)
+    if isinstance(node, dict):
+        # A group node (root or intermediate): list its children. Reached when no
+        # positional selects a leaf — e.g. no args, a trailing ``--help``, or a
+        # bare group name.
+        _print_group_help(node, path)
+        return None
+    # Config leaf: remaining args are its overrides. Handle ``--help`` ourselves so
+    # fire doesn't intercept it, then let fire parse the ``--kwargs`` (``command=rest``
+    # keeps fire from re-reading the already-consumed positional path off sys.argv).
+    runner = _cli_single_command(node)
+    if '--help' in rest:
+        return runner(help=True)
+    return fire.Fire(runner, command=rest)
 
 
-def cli(config: Config | dict[str, Config]):
+def cli(config: Config | CommandTree):
     """
     Run a config object(s) as a CLI.
 
     Args:
-        config: The config or dict of configs to run. If dict is provided, each key is a command name
-         and each value is a config object.
+        config: A single config, or a (possibly nested) dict of configs forming a
+         command tree. Each non-dict leaf is a config; positional args walk the
+         tree by key until a leaf is reached, then ``--kwargs`` override it.
 
     Example:
         >>> @cfn.config()
@@ -128,9 +162,13 @@ def cli(config: Config | dict[str, Config]):
         >>> # Shell call: python script.py product --a 1 --b 2
         >>> # Shell call: python script.py --help
         >>> # Shell call: python script.py sum --help
+
+        >>> cfn.cli({'math': {'sum': sum, 'product': product}})
+        >>> # Shell call: python script.py math sum --a 1 --b 2
+        >>> # Shell call: python script.py math --help
     """
 
     if isinstance(config, dict):
-        return _cli_multiple_commands(config)
+        return _cli_command_tree(config)
     else:
         fire.Fire(_cli_single_command(config))

--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -120,15 +120,16 @@ def _cli_command_tree(tree: CommandTree):
     args = sys.argv[1:]
     node, path, rest = _walk_tree(tree, args)
     if isinstance(node, dict):
-        # A group node (root or intermediate): list its children — but only for no
-        # args or an explicit ``--help``. An option-looking token before any leaf is
-        # selected (e.g. ``--typo``) is a mistake, not a request for help: reject it,
-        # matching the flat-dict "Command not found" behavior instead of silently
-        # printing help and exiting 0.
-        if rest and '--help' not in rest:
+        # A group node (root or intermediate): list its children — but only for a bare
+        # group or an exact ``--help`` request. Any other option-looking token (e.g.
+        # ``--typo``), even when ``--help`` is also present, is a mistake rather than a
+        # request for help: reject it, matching the flat-dict "Command not found"
+        # behavior instead of silently printing help and exiting 0.
+        unknown = [token for token in rest if token != '--help']
+        if unknown:
             available = list(node.keys())
             scope = f" under '{' '.join(path)}'" if path else ''
-            raise ValueError(f"Command '{rest[0]}' not found{scope}. Available commands: {available}")
+            raise ValueError(f"Command '{unknown[0]}' not found{scope}. Available commands: {available}")
         _print_group_help(node, path)
         return None
     # Config leaf: remaining args are its overrides. Handle ``--help`` ourselves so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.4.0"
+version = "0.5.0"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,3 +266,43 @@ def test_cli_nested_tree_leaf_help_lists_required_args(capfd):
         out, err = capfd.readouterr()
         assert 'a: <REQUIRED>' in out
         assert 'b: <REQUIRED>' in out
+
+
+def test_cli_leaf_help_reflects_overrides(capfd):
+    """`cmd --a=1 --help` must apply the override before printing help, so `a` is no
+    longer reported as required."""
+
+    @cfn.config()
+    def add(a, b):
+        print(a + b)
+
+    with patch('sys.argv', ['script.py', 'func', '--a=1', '--help']):
+        cfn.cli({'func': add})
+        out, err = capfd.readouterr()
+        assert 'b: <REQUIRED>' in out
+        assert 'a: <REQUIRED>' not in out
+
+
+def test_cli_group_rejects_unknown_option(capfd):
+    """An option-looking token before any leaf is selected is a typo, not a help request."""
+
+    @cfn.config()
+    def func1(a):
+        print(a)
+
+    with patch('sys.argv', ['script.py', '--typo']):
+        with pytest.raises(ValueError) as e:
+            cfn.cli({'func1': func1})
+        assert "Command '--typo' not found. Available commands: ['func1']" in str(e.value)
+
+
+def test_cli_nested_group_rejects_unknown_option(capfd):
+    @cfn.config()
+    def add(a):
+        print(a)
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py', 'math', '--typo']):
+        with pytest.raises(ValueError) as e:
+            cfn.cli(tree)
+        assert "Command '--typo' not found under 'math'. Available commands: ['add']" in str(e.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,21 +24,20 @@ def test_cli_help_prints_has_required_args(capfd):
     with patch('sys.argv', ['script.py', '--help']):
         cfn.cli(identity)
         out, err = capfd.readouterr()
-        assert "a: <REQUIRED>" in out
-        assert "b: <REQUIRED>" in out
+        assert 'a: <REQUIRED>' in out
+        assert 'b: <REQUIRED>' in out
 
 
 def test_cli_help_prints_docstring(capfd):
     @cfn.config()
     def identity(a, b):
-        """This is a test function.
-        """
+        """This is a test function."""
         print(a, b)
 
     with patch('sys.argv', ['script.py', '--help']):
         cfn.cli(identity)
         out, err = capfd.readouterr()
-        assert "This is a test function." in out
+        assert 'This is a test function.' in out
 
 
 def test_cli_help_prints_nested_required_args(capfd):
@@ -53,75 +52,76 @@ def test_cli_help_prints_nested_required_args(capfd):
     with patch('sys.argv', ['script.py', '--help']):
         cfn.cli(func)
         out, err = capfd.readouterr()
-        assert "a.req_arg: <REQUIRED>" in out
+        assert 'a.req_arg: <REQUIRED>' in out
 
 
 def test_cli_multiple_commands_call_overrides_arg(capfd):
     @cfn.config()
     def func1(a):
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     @cfn.config()
     def func2(b):
-        print(f"b: {b}")
+        print(f'b: {b}')
 
     with patch('sys.argv', ['script.py', 'func1', '--a=1']):
         cfn.cli({'func1': func1, 'func2': func2})
         out, err = capfd.readouterr()
         assert out == 'a: 1\n'
 
+
 def test_cli_multiple_commands_help_prints_commands_list(capfd):
     @cfn.config()
     def func1(a):
         """Docstring for func1"""
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     @cfn.config()
     def func2(b):
         """Docstring for func2"""
-        print(f"b: {b}")
+        print(f'b: {b}')
 
     with patch('sys.argv', ['script.py', '--help']):
         cfn.cli({'func1': func1, 'func2': func2})
         out, err = capfd.readouterr()
-        assert "python script.py func1 --a=<REQUIRED> # Docstring for func1" in out
-        assert "python script.py func2 --b=<REQUIRED> # Docstring for func2" in out
+        assert 'python script.py func1 --a=<REQUIRED> # Docstring for func1' in out
+        assert 'python script.py func2 --b=<REQUIRED> # Docstring for func2' in out
 
 
 def test_cli_multiple_commands_no_docstring_help_prints_commands_list(capfd):
     @cfn.config()
     def func_no_docstring(a):
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     with patch('sys.argv', ['script.py', '--help']):
         cfn.cli({'func_no_docstring': func_no_docstring})
         out, err = capfd.readouterr()
-        assert "python script.py func_no_docstring --a=<REQUIRED>" in out
+        assert 'python script.py func_no_docstring --a=<REQUIRED>' in out
 
 
 def test_cli_multiple_commands_help_prints_command_help(capfd):
     @cfn.config()
     def func1(a):
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     @cfn.config()
     def func2(b):
-        print(f"b: {b}")
+        print(f'b: {b}')
 
     with patch('sys.argv', ['script.py', 'func1', '--help']):
         cfn.cli({'func1': func1, 'func2': func2})
         out, err = capfd.readouterr()
-        assert "a: <REQUIRED>" in out
+        assert 'a: <REQUIRED>' in out
 
 
 def test_cli_multiple_commands_unknown_command_raises_error(capfd):
     @cfn.config()
     def func1(a):
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     @cfn.config()
     def func2(b):
-        print(f"b: {b}")
+        print(f'b: {b}')
 
     with patch('sys.argv', ['script.py', 'func3']):
         with pytest.raises(ValueError) as e:
@@ -132,11 +132,11 @@ def test_cli_multiple_commands_unknown_command_raises_error(capfd):
 def test_cli_multiple_commands_unknown_command_with_help_raises_error(capfd):
     @cfn.config()
     def func1(a):
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     @cfn.config()
     def func2(b):
-        print(f"b: {b}")
+        print(f'b: {b}')
 
     with patch('sys.argv', ['script.py', 'func3', '--help']):
         with pytest.raises(ValueError) as e:
@@ -147,12 +147,12 @@ def test_cli_multiple_commands_unknown_command_with_help_raises_error(capfd):
 def test_cli_multiple_commands_print_help_if_no_args_provided(capfd):
     @cfn.config()
     def func1(a):
-        print(f"a: {a}")
+        print(f'a: {a}')
 
     with patch('sys.argv', ['script.py']):
         cfn.cli({'func1': func1})
         out, err = capfd.readouterr()
-        assert "python script.py func1 --a=<REQUIRED>" in out
+        assert 'python script.py func1 --a=<REQUIRED>' in out
 
 
 def test_cli_accepts_leading_dot_strings_as_literals(capfd):
@@ -177,3 +177,92 @@ def test_cli_accepts_leading_dot_strings_as_literals(capfd):
         cfn.cli(echo)
         out, err = capfd.readouterr()
         assert out.strip() == '.env'
+
+
+def test_cli_nested_tree_dispatches_to_leaf(capfd):
+    @cfn.config()
+    def add(a, b):
+        print(f'sum: {a + b}')
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py', 'math', 'add', '--a=1', '--b=2']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert out == 'sum: 3\n'
+
+
+def test_cli_nested_tree_group_help_lists_children(capfd):
+    @cfn.config()
+    def add(a, b):
+        """Add two numbers"""
+        print(a + b)
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py', 'math', '--help']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert 'python script.py math add --a=<REQUIRED> --b=<REQUIRED> # Add two numbers' in out
+
+
+def test_cli_nested_tree_bare_group_lists_children(capfd):
+    @cfn.config()
+    def add(a):
+        print(a)
+
+    tree = {'math': {'add': add}}
+    # A bare group name (no further positional, no --help) lists the group's children.
+    with patch('sys.argv', ['script.py', 'math']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert 'python script.py math add --a=<REQUIRED>' in out
+
+
+def test_cli_root_help_lists_intermediate_groups(capfd):
+    @cfn.config()
+    def add(a):
+        print(a)
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert 'python script.py math <command> ...' in out
+
+
+def test_cli_flat_dotted_catalog_key_is_a_leaf(capfd):
+    """The eval catalog is a flat dict of dotted keys nested under a group."""
+
+    @cfn.config()
+    def run_eval(eval_name, policy):
+        print(f'{eval_name}:{policy}')
+
+    tree = {'eval': {'run': {'sim.positronic.stack_cubes': run_eval.override(eval_name='stack_cubes')}}}
+    with patch('sys.argv', ['script.py', 'eval', 'run', 'sim.positronic.stack_cubes', '--policy=remote']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert out == 'stack_cubes:remote\n'
+
+
+def test_cli_nested_tree_unknown_key_reports_path(capfd):
+    @cfn.config()
+    def add(a):
+        print(a)
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py', 'math', 'nope']):
+        with pytest.raises(ValueError) as e:
+            cfn.cli(tree)
+        assert "Command 'nope' not found under 'math'. Available commands: ['add']" in str(e.value)
+
+
+def test_cli_nested_tree_leaf_help_lists_required_args(capfd):
+    @cfn.config()
+    def add(a, b):
+        print(a + b)
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py', 'math', 'add', '--help']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert 'a: <REQUIRED>' in out
+        assert 'b: <REQUIRED>' in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,3 +306,22 @@ def test_cli_nested_group_rejects_unknown_option(capfd):
         with pytest.raises(ValueError) as e:
             cfn.cli(tree)
         assert "Command '--typo' not found under 'math'. Available commands: ['add']" in str(e.value)
+
+
+def test_cli_group_rejects_unknown_option_even_with_help(capfd):
+    """An unknown group-level option must error even when `--help` is also present."""
+
+    @cfn.config()
+    def add(a):
+        print(a)
+
+    with patch('sys.argv', ['script.py', '--typo', '--help']):
+        with pytest.raises(ValueError) as e:
+            cfn.cli({'func': add})
+        assert "Command '--typo' not found. Available commands: ['func']" in str(e.value)
+
+    tree = {'math': {'add': add}}
+    with patch('sys.argv', ['script.py', 'math', '--typo', '--help']):
+        with pytest.raises(ValueError) as e:
+            cfn.cli(tree)
+        assert "Command '--typo' not found under 'math'. Available commands: ['add']" in str(e.value)


### PR DESCRIPTION
## Summary
- `cfn.cli` now accepts arbitrarily-nested dicts of `Config`s: positional args walk the tree by key to a `Config` leaf, then `--kwargs` override and instantiate it (e.g. `script.py group subcommand --param=value`)
- `--help` lists child commands at a group node, required args at a leaf
- The flat `{'cmd': cfg}` form is the depth-1 special case and is unchanged
- Bump version `0.4.0` → `0.5.0` and add CHANGELOG entry (v0.4.0 is already released; nested CLI is a backward-compatible feature)

## Test plan
- `uv run pytest` — 126 passed (12 original CLI tests + 8 new nested-tree tests), `cli.py` at 98.6% coverage