### PR TITLE
Add default command support to cli() and document .override() idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Nested command trees in `cfn.cli`. The dict form now accepts arbitrarily-nested dicts of `Config`s: positional args walk the tree by key until a `Config` leaf, then `--kwargs` override and instantiate it (e.g. `script.py group subcommand --param=value`). `--help` lists child commands at a group node and required args at a leaf. The previous flat `{'cmd': cfg}` form is the depth-1 special case and is unchanged.
 - Default command in `cfn.cli(dict)` via an empty-string (`''`) key (#28). The `''` config is run when a command-tree group is reached without naming a child — i.e. with no args or a leading option (`python script.py` or `python script.py --param=value`). A non-option word that isn't a known command still errors, so typos don't silently fall through. `--help` lists the group's children and flags the default. Works at the root and at intermediate group nodes.
 
+### Fixed
+- `override()` / `copy()` now produce a fully independent config. Previously only top-level `Config` kwargs were copied, so a dotted override reaching through a shared `dict`/`list`/`tuple` (e.g. `base.override(**{'cameras.left.fps': 60})`) mutated the base and sibling variants. Nested `Config`s inside containers are now copied too.
+
 ### Documentation
 - Documented the core "one general config + named `.override()` variants" idiom and contrasted it with writing near-duplicate config functions (#29). Added README sections "Variants via `.override()`" and "Instantiation semantics", and expanded the `Config.override`, `Config.instantiate`, and `cli` docstrings.
 - Clarified instantiation semantics: a config is a closure and each `Config` reference is instantiated independently (no caching); to share one object across components, bind them together by passing it as a single argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,15 @@
 # Changelog
 
-## [0.6.0] - 2026-06-09
-
-### Added
-- Default command in `cfn.cli(dict)` via an empty-string (`''`) key (#28). The `''` config is run when a command-tree group is reached without naming a child — i.e. with no args or a leading option (`python script.py` or `python script.py --param=value`). A non-option word that isn't a known command still errors, so typos don't silently fall through. `--help` lists the group's children and flags the default. Works at the root and at intermediate group nodes.
-
-### Documentation
-- Documented the core "one general config + named `.override()` variants" idiom and contrasted it with the duplicate-config-functions anti-pattern (#29). Added README sections "Variants via `.override()`" and "Instantiation semantics", and expanded the `Config.override`, `Config.instantiate`, and `cli` docstrings.
-- Clarified instantiation semantics: each `Config` reference is instantiated independently (no memoization); to share one instance across slots, return the group as a bundle from a single config.
-- Updated the multi-config Best Practices example to use `cfn.cli(dict)` (with a default command) instead of manual `sys.argv` dispatch.
-
-## [0.5.0] - 2026-05-31
+## [0.5.0] - 2026-06-09
 
 ### Added
 - Nested command trees in `cfn.cli`. The dict form now accepts arbitrarily-nested dicts of `Config`s: positional args walk the tree by key until a `Config` leaf, then `--kwargs` override and instantiate it (e.g. `script.py group subcommand --param=value`). `--help` lists child commands at a group node and required args at a leaf. The previous flat `{'cmd': cfg}` form is the depth-1 special case and is unchanged.
+- Default command in `cfn.cli(dict)` via an empty-string (`''`) key (#28). The `''` config is run when a command-tree group is reached without naming a child — i.e. with no args or a leading option (`python script.py` or `python script.py --param=value`). A non-option word that isn't a known command still errors, so typos don't silently fall through. `--help` lists the group's children and flags the default. Works at the root and at intermediate group nodes.
+
+### Documentation
+- Documented the core "one general config + named `.override()` variants" idiom and contrasted it with writing near-duplicate config functions (#29). Added README sections "Variants via `.override()`" and "Instantiation semantics", and expanded the `Config.override`, `Config.instantiate`, and `cli` docstrings.
+- Clarified instantiation semantics: a config is a closure and each `Config` reference is instantiated independently (no caching); to share one object across components, bind them together by passing it as a single argument.
+- Updated the multi-config Best Practices example to use `cfn.cli(dict)` (with a default command) instead of manual `sys.argv` dispatch.
 
 ## [0.4.0] - 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0] - 2026-06-09
+
+### Added
+- Default command in `cfn.cli(dict)` via an empty-string (`''`) key (#28). The `''` config is run when a command-tree group is reached without naming a child — i.e. with no args or a leading option (`python script.py` or `python script.py --param=value`). A non-option word that isn't a known command still errors, so typos don't silently fall through. `--help` lists the group's children and flags the default. Works at the root and at intermediate group nodes.
+
+### Documentation
+- Documented the core "one general config + named `.override()` variants" idiom and contrasted it with the duplicate-config-functions anti-pattern (#29). Added README sections "Variants via `.override()`" and "Instantiation semantics", and expanded the `Config.override`, `Config.instantiate`, and `cli` docstrings.
+- Clarified instantiation semantics: each `Config` reference is instantiated independently (no memoization); to share one instance across slots, return the group as a bundle from a single config.
+- Updated the multi-config Best Practices example to use `cfn.cli(dict)` (with a default command) instead of manual `sys.argv` dispatch.
+
 ## [0.5.0] - 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,90 @@ fast_training = training_cfg.override(**{
 })
 ```
 
+### Variants via `.override()` (the core idiom)
+
+For real projects, the pattern you'll reach for most is **one general config plus
+named variants derived with `.override()`** — *not* a dict of unrelated config
+functions. Define the shared base once, then specialize it:
+
+```python
+# ONE general config — the factory and its shared defaults.
+single_arm = cfn.Config(build_embodiment, robot_arm=franka, gripper=robotiq, cameras={})
+
+# Named variants are just overrides of that base. Use dotted keys to reach
+# into sub-configs and list/dict slots.
+droid = single_arm.override(
+    robot_arm=franka_droid,
+    cameras={'wrist': wrist_cam, 'scene': scene_cam},
+)
+sim = single_arm.override(
+    robot_arm=franka_sim,
+    **{'robot_arm.collision_coeff': 2.0},   # nested, dotted override
+)
+
+# Expose the variants as CLI commands by passing a dict of overrides to cli().
+if __name__ == "__main__":
+    cfn.cli({'droid': droid, 'sim': sim})
+```
+
+```bash
+python embodiment.py droid --gripper="@my.grippers.Wsg"
+python embodiment.py sim --robot_arm.collision_coeff=4.0
+```
+
+**Anti-pattern — don't do this:** writing several near-duplicate `@cfn.config`
+functions that each rebuild the same object and differ only in a few arguments.
+
+```python
+# ❌ Duplicated construction logic, drifts out of sync, harder to override from CLI.
+@cfn.config(robot_arm=..., gripper=..., cameras={...})
+def droid(robot_arm, gripper, cameras):
+    return build_embodiment(robot_arm, gripper, cameras, simulated=False)
+
+@cfn.config(mujoco_model_path=...)
+def sim(mujoco_model_path, ...):
+    ...  # rebuild devices by hand
+    return build_embodiment(robot_arm, gripper, cameras, simulated=True)
+```
+
+When two configs share a factory and differ only in their arguments, prefer
+`base.override(...)` over a second `@cfn.config` function. Concrete (non-`Config`)
+override values pass straight through, and dotted keys let you tweak nested
+sub-configs without redefining the base.
+
+### Instantiation semantics (shared instances)
+
+Each referenced `Config` is instantiated **independently** — there is **no instance
+memoization or identity sharing**. If the same sub-config is referenced from several
+slots, it is built **once per slot**, producing that many distinct objects:
+
+```python
+mujoco = cfn.Config(MujocoSim, model_path="scene.xml")
+
+# ❌ Three references -> THREE separate MujocoSim instances, not one shared sim.
+embodiment = cfn.Config(
+    Embodiment,
+    robot_arm=cfn.Config(SimArm, sim=mujoco),
+    gripper=cfn.Config(SimGripper, sim=mujoco),
+    cameras={'wrist': cfn.Config(SimCamera, sim=mujoco)},
+)
+```
+
+To share a single instance across slots, build it inside one config that returns the
+group as a **bundle** (a dataclass, namedtuple, or dict), and reference that bundle:
+
+```python
+# ✅ Build the shared sim and all devices together; one MujocoSim is created.
+@cfn.config(model_path="scene.xml")
+def sim_devices(model_path: str):
+    sim = MujocoSim(model_path)
+    return {
+        'robot_arm': SimArm(sim),
+        'gripper': SimGripper(sim),
+        'cameras': {'wrist': SimCamera(sim)},
+    }
+```
+
 ## 🌍 Real-World Examples
 
 ### Robotics Hardware Configuration
@@ -457,6 +541,26 @@ python script.py sum --help
 # Shows detailed help for the sum command
 ```
 
+#### Default command (no subcommand name)
+
+An empty-string (`''`) key marks a **default command** — the one run when no command
+is named. This lets a tool expose named presets *and* a primary, flags-only path:
+
+```python
+cfn.cli({'': default_cfg, 'sim': sim_cfg})
+```
+
+```bash
+python script.py                       # -> default_cfg (no overrides)
+python script.py --embodiment=droid    # -> default_cfg with the override applied
+python script.py sim --x=1             # -> sim_cfg (named command, unchanged)
+python script.py --help                # -> lists commands and flags the default
+```
+
+A non-option word that isn't a known command still errors (so typos don't silently
+fall through to the default) — only no arguments or a leading `--option` dispatch to
+the default.
+
 ### Parameter Override Order ⚠️
 
 **Important:** Parameter overrides are executed in order of declaration. When overriding nested configurations, set the parent object first, then its properties:
@@ -501,7 +605,7 @@ def my_function(...):
 Generate automatic command-line interface for any configuration or multiple configurations.
 
 **Parameters:**
-- `config`: Either a single `Config` object or a dictionary mapping command names to `Config` objects
+- `config`: Either a single `Config` object or a (possibly nested) dict mapping command names to `Config`s. An empty-string (`''`) key marks the default command, run when no command is named.
 
 **Examples:**
 ```python
@@ -510,6 +614,9 @@ cfn.cli(my_config)
 
 # Multiple commands
 cfn.cli({'train': train_config, 'eval': eval_config, 'test': test_config})
+
+# With a default command (run when no subcommand is given)
+cfn.cli({'': train_config, 'eval': eval_config})
 ```
 
 #### `get_required_args(config: Config) -> List[str]`
@@ -626,25 +733,21 @@ experimental_training = base_training.override(
 debug_training = base_training.override(
     epochs=1, batch_size=2, **{"model.layers": 1})
 
-# Now you can easily switch between configurations
-# TODO: Make this part of Configuronic
+# Pass the variants to cli() as a dict to switch between them from the command line.
+# Make 'dev' the default command (run when no preset is named) via the '' key.
 if __name__ == "__main__":
-    import sys
-    configs = {
+    cfn.cli({
+        '': dev_training,            # default: `python train.py` runs dev
         'dev': dev_training,
         'prod': prod_training,
         'experimental': experimental_training,
-        'debug': debug_training
-    }
-
-    config_name = sys.argv[1] if len(sys.argv) > 1 else 'dev'
-    selected_config = configs.get(config_name, dev_training)
-
-    cfn.cli(selected_config)
+        'debug': debug_training,
+    })
 ```
 
 **Usage:**
 ```bash
+python train.py              # Use the default (dev) config
 python train.py dev          # Use development config
 python train.py prod         # Use production config
 python train.py experimental # Use experimental config

--- a/README.md
+++ b/README.md
@@ -186,35 +186,46 @@ sub-configs without redefining the base.
 
 ### Instantiation semantics (shared instances)
 
-Each referenced `Config` is instantiated **independently** — there is **no instance
-memoization or identity sharing**. If the same sub-config is referenced from several
-slots, it is built **once per slot**, producing that many distinct objects:
+When a config is instantiated, every `Config` it references is built **independently** —
+configuronic does not cache or reuse instances. So if the same sub-config appears in
+more than one place, each place gets its **own** freshly-built object.
+
+Most of the time that's exactly what you want. It only matters when you intend several
+components to share **one** object — for example a single database connection, an open
+session, or a random generator with a fixed seed. Referencing the same sub-config from
+several slots will *not* share that object; you silently get separate copies, and state
+set through one is invisible to the others.
 
 ```python
-mujoco = cfn.Config(MujocoSim, model_path="scene.xml")
+@cfn.config(url="postgres://localhost/app")
+def database(url: str):
+    return Database(url)
 
-# ❌ Three references -> THREE separate MujocoSim instances, not one shared sim.
-embodiment = cfn.Config(
-    Embodiment,
-    robot_arm=cfn.Config(SimArm, sim=mujoco),
-    gripper=cfn.Config(SimGripper, sim=mujoco),
-    cameras={'wrist': cfn.Config(SimCamera, sim=mujoco)},
-)
+@cfn.config(db=database)
+def reader(db):
+    ...
+
+@cfn.config(db=database)
+def writer(db):
+    ...
+
+# `database` is referenced twice, so `reader` and `writer` each get their OWN
+# Database — two connections, not one shared connection.
+@cfn.config(reader=reader, writer=writer)
+def app(reader, writer):
+    ...
 ```
 
-To share a single instance across slots, build it inside one config that returns the
-group as a **bundle** (a dataclass, namedtuple, or dict), and reference that bundle:
+If you really need one shared instance, create it once inside a single config function
+and pass it to everyone that needs it, instead of referencing the same sub-config from
+each slot:
 
 ```python
-# ✅ Build the shared sim and all devices together; one MujocoSim is created.
-@cfn.config(model_path="scene.xml")
-def sim_devices(model_path: str):
-    sim = MujocoSim(model_path)
-    return {
-        'robot_arm': SimArm(sim),
-        'gripper': SimGripper(sim),
-        'cameras': {'wrist': SimCamera(sim)},
-    }
+# ✅ One Database is created and shared by both the reader and the writer.
+@cfn.config(url="postgres://localhost/app")
+def app(url: str):
+    db = Database(url)
+    return App(reader=Reader(db), writer=Writer(db))
 ```
 
 ## 🌍 Real-World Examples

--- a/README.md
+++ b/README.md
@@ -184,49 +184,33 @@ When two configs share a factory and differ only in their arguments, prefer
 override values pass straight through, and dotted keys let you tweak nested
 sub-configs without redefining the base.
 
-### Instantiation semantics (shared instances)
+### Instantiation semantics
 
-When a config is instantiated, every `Config` it references is built **independently** —
-configuronic does not cache or reuse instances. So if the same sub-config appears in
-more than one place, each place gets its **own** freshly-built object.
+A config is just a **closure**: it remembers a callable and its arguments, and
+instantiating it calls that callable and returns a fresh result. There is no caching —
+every referenced `Config` is built independently, so referencing the same sub-config
+from two places produces two separate objects.
 
-Most of the time that's exactly what you want. It only matters when you intend several
-components to share **one** object — for example a single database connection, an open
-session, or a random generator with a fixed seed. Referencing the same sub-config from
-several slots will *not* share that object; you silently get separate copies, and state
-set through one is invisible to the others.
+This shapes how you share an object. When several components depend on the **same**
+object — a database connection, a session, a seeded random generator — bind them
+together: take that object as a single argument and build the dependents from it. The
+closure then captures one shared instance.
 
 ```python
 @cfn.config(url="postgres://localhost/app")
 def database(url: str):
     return Database(url)
 
+# `Reader` and `Writer` must talk to the same database, so they belong together:
+# `db` is one argument, instantiated once, and shared by both.
 @cfn.config(db=database)
-def reader(db):
-    ...
-
-@cfn.config(db=database)
-def writer(db):
-    ...
-
-# `database` is referenced twice, so `reader` and `writer` each get their OWN
-# Database — two connections, not one shared connection.
-@cfn.config(reader=reader, writer=writer)
-def app(reader, writer):
-    ...
-```
-
-If you really need one shared instance, create it once inside a single config function
-and pass it to everyone that needs it, instead of referencing the same sub-config from
-each slot:
-
-```python
-# ✅ One Database is created and shared by both the reader and the writer.
-@cfn.config(url="postgres://localhost/app")
-def app(url: str):
-    db = Database(url)
+def app(db):
     return App(reader=Reader(db), writer=Writer(db))
 ```
+
+Don't try to share by pointing several slots at the same sub-config — each slot would
+build its own copy, which is the independent-instantiation rule above, not sharing.
+Keep things that depend on one object bound together instead.
 
 ## 🌍 Real-World Examples
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,13 @@ python embodiment.py droid --gripper="@my.grippers.Wsg"
 python embodiment.py sim --robot_arm.collision_coeff=4.0
 ```
 
-**Less recommended:** writing several near-duplicate `@cfn.config` functions that
-each rebuild the same object and differ only in a few arguments.
+**Not recommended:** writing several near-duplicate `@cfn.config` functions that each
+rebuild the same object and differ in only a few arguments — a later change to the
+shared construction then has to be copied into every one, whereas `.override()` variants
+inherit it automatically (DRY).
 
 ```python
-# Works, but duplicates the construction logic, which can drift out of sync and is
-# harder to override from the CLI.
+# Each function re-declares the construction, so every change must be duplicated.
 @cfn.config(robot_arm=..., gripper=..., cameras={...})
 def droid(robot_arm, gripper, cameras):
     return build_embodiment(robot_arm, gripper, cameras, simulated=False)
@@ -178,11 +179,6 @@ def sim(mujoco_model_path, ...):
     ...  # rebuild devices by hand
     return build_embodiment(robot_arm, gripper, cameras, simulated=True)
 ```
-
-When two configs share a factory and differ only in their arguments, prefer
-`base.override(...)` over a second `@cfn.config` function. Concrete (non-`Config`)
-override values pass straight through, and dotted keys let you tweak nested
-sub-configs without redefining the base.
 
 ### Instantiation semantics
 
@@ -207,10 +203,6 @@ def database(url: str):
 def app(db):
     return App(reader=Reader(db), writer=Writer(db))
 ```
-
-Don't try to share by pointing several slots at the same sub-config — each slot would
-build its own copy, which is the independent-instantiation rule above, not sharing.
-Keep things that depend on one object bound together instead.
 
 ## 🌍 Real-World Examples
 

--- a/README.md
+++ b/README.md
@@ -163,11 +163,12 @@ python embodiment.py droid --gripper="@my.grippers.Wsg"
 python embodiment.py sim --robot_arm.collision_coeff=4.0
 ```
 
-**Anti-pattern — don't do this:** writing several near-duplicate `@cfn.config`
-functions that each rebuild the same object and differ only in a few arguments.
+**Less recommended:** writing several near-duplicate `@cfn.config` functions that
+each rebuild the same object and differ only in a few arguments.
 
 ```python
-# ❌ Duplicated construction logic, drifts out of sync, harder to override from CLI.
+# Works, but duplicates the construction logic, which can drift out of sync and is
+# harder to override from the CLI.
 @cfn.config(robot_arm=..., gripper=..., cameras={...})
 def droid(robot_arm, gripper, cameras):
     return build_embodiment(robot_arm, gripper, cameras, simulated=False)

--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -133,15 +133,19 @@ def _cli_command_tree(tree: CommandTree):
     if isinstance(node, dict):
         default = node.get(DEFAULT_COMMAND)
         if default is not None:
-            # A group with a default command. ``--help`` lists the group's children
-            # (flagging the default); otherwise run the default, passing the remaining
-            # tokens as overrides. A non-option positional that isn't a known command
-            # already raised in ``_walk_tree``, so ``rest`` here is empty or starts with
-            # an option token.
-            if '--help' in rest:
+            # A group with a default command. A bare ``--help`` lists the group's
+            # children (flagging the default). Otherwise run the default, passing the
+            # remaining tokens as overrides — including ``--x=v --help``, where we apply
+            # the overrides and show the default command's help, mirroring the leaf path.
+            # A non-option positional that isn't a known command already raised in
+            # ``_walk_tree``, so ``rest`` here is empty or starts with an option token.
+            overrides = [a for a in rest if a != '--help']
+            if '--help' in rest and not overrides:
                 _print_group_help(node, path)
                 return None
             runner = _cli_single_command(default)
+            if '--help' in rest:
+                return fire.Fire(lambda **kwargs: runner(help=True, **kwargs), command=overrides)
             return fire.Fire(runner, command=rest)
         # A group node (root or intermediate): list its children — but only for a bare
         # group or an exact ``--help`` request. Any other option-looking token (e.g.

--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -197,6 +197,17 @@ def cli(config: Config | CommandTree):
         >>> # Shell call: python script.py --help
         >>> # Shell call: python script.py sum --help
 
+        The more common real-world shape: the dict values are variants of one general
+        config, derived with ``.override()`` instead of duplicate config functions.
+
+        >>> single_arm = cfn.Config(build, robot_arm=franka, gripper=robotiq)
+        >>> cfn.cli({
+        ...     'droid': single_arm.override(robot_arm=franka_droid),
+        ...     'sim': single_arm.override(robot_arm=franka_sim),
+        ... })
+        >>> # Shell call: python script.py droid --gripper=@my.grippers.Wsg
+        >>> # Shell call: python script.py sim --robot_arm.collision_coeff=2.0
+
         >>> cfn.cli({'math': {'sum': sum, 'product': product}})
         >>> # Shell call: python script.py math sum --a 1 --b 2
         >>> # Shell call: python script.py math --help

--- a/configuronic/cli.py
+++ b/configuronic/cli.py
@@ -74,6 +74,10 @@ def _cli_single_command(config: Config):
 # (``-``-prefixed) or a Config leaf ends the walk.
 CommandTree = dict[str, 'Config | CommandTree']
 
+# An empty-string key in a group node marks the *default command*: the one run when
+# the group is reached without naming a child (no positional args, or a leading option).
+DEFAULT_COMMAND = ''
+
 
 def _walk_tree(tree: CommandTree, args: list[str]) -> tuple[Config | CommandTree, list[str], list[str]]:
     """Walk positional args down the command tree.
@@ -112,7 +116,14 @@ def _print_group_help(node: CommandTree, path: list[str]):
             command_description = ''
         required_args = get_required_args(child)
         required_args_str = ' '.join([f'--{arg}=<REQUIRED>' for arg in required_args])
-        print(f'python {sys.argv[0]} {prefix}{command} {required_args_str}{command_description}')
+        if command == DEFAULT_COMMAND:
+            # The default command is invoked without naming it (no positional args, or a
+            # leading option). Drop the empty name and flag it as the default.
+            invocation = ' '.join(filter(None, [f'python {sys.argv[0]}', prefix.strip(), required_args_str]))
+            doc = command_description.replace(' # ', ' ', 1) if command_description else ''
+            print(f'{invocation} # default command{doc}')
+        else:
+            print(f'python {sys.argv[0]} {prefix}{command} {required_args_str}{command_description}')
     print()
 
 
@@ -120,6 +131,18 @@ def _cli_command_tree(tree: CommandTree):
     args = sys.argv[1:]
     node, path, rest = _walk_tree(tree, args)
     if isinstance(node, dict):
+        default = node.get(DEFAULT_COMMAND)
+        if default is not None:
+            # A group with a default command. ``--help`` lists the group's children
+            # (flagging the default); otherwise run the default, passing the remaining
+            # tokens as overrides. A non-option positional that isn't a known command
+            # already raised in ``_walk_tree``, so ``rest`` here is empty or starts with
+            # an option token.
+            if '--help' in rest:
+                _print_group_help(node, path)
+                return None
+            runner = _cli_single_command(default)
+            return fire.Fire(runner, command=rest)
         # A group node (root or intermediate): list its children — but only for a bare
         # group or an exact ``--help`` request. Any other option-looking token (e.g.
         # ``--typo``), even when ``--help`` is also present, is a mistake rather than a
@@ -177,6 +200,16 @@ def cli(config: Config | CommandTree):
         >>> cfn.cli({'math': {'sum': sum, 'product': product}})
         >>> # Shell call: python script.py math sum --a 1 --b 2
         >>> # Shell call: python script.py math --help
+
+        An empty-string ('') key marks a *default command*, run when no command is
+        named — i.e. with no args or a leading option. A non-option word that isn't a
+        known command still errors, so typos don't silently fall through.
+
+        >>> cfn.cli({'': default_cfg, 'sim': sim_cfg})
+        >>> # Shell call: python script.py                  -> default_cfg (no overrides)
+        >>> # Shell call: python script.py --embodiment=droid -> default_cfg with override
+        >>> # Shell call: python script.py sim --x=1          -> sim_cfg
+        >>> # Shell call: python script.py --help             -> lists commands, flags the default
     """
 
     if isinstance(config, dict):

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -378,13 +378,12 @@ class Config:
         """
         Instatiate the target function with the given arguments and keyword arguments.
 
-        Instantiation semantics: every referenced ``Config`` is built independently —
-        configuronic does not cache or reuse instances. If the same sub-config appears
-        in more than one place, each place gets its own freshly-built object. This
-        matters only when you intend several components to share one object (e.g. a
-        single connection or session): to do that, create the object once inside a
-        single config function and pass it to everyone that needs it, instead of
-        referencing the same sub-config from each slot.
+        Instantiation semantics: a config is a closure, and every referenced ``Config``
+        is built independently — there is no caching. Referencing the same sub-config
+        from two places produces two separate objects. To let several components share
+        one object, bind them together: take that object as a single argument and build
+        the dependents from it, rather than pointing several slots at the same
+        sub-config.
 
         Returns:
             The instantiated target function.

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -289,8 +289,23 @@ class Config:
         """
         Create a new Config with updated parameters.
 
-        Supports nested parameter updates using dot notation (e.g. "model.layers").
-        Handles absolute imports (@) and relative imports (.).
+        This is the idiomatic way to derive named variants from one general config:
+        define a single base ``Config`` and produce each variant with ``.override()``,
+        rather than writing several near-duplicate config functions. Pass a dict of such
+        variants to :func:`configuronic.cli` to expose them as CLI commands.
+
+        Keys may be nested using dot notation to reach into sub-configs and into
+        list/dict slots (e.g. ``"model.layers"``, ``"robot_arm.collision_coeff"``,
+        ``"cameras.left.fps"``, ``"loaders.0.fps"``).
+
+        Values are resolved by type:
+        - strings may use absolute imports (``@module.path.Object``) or relative
+          imports (``.SiblingObject``);
+        - concrete (non-``Config``) values — ints, floats, objects, ``Config`` instances,
+          lists, dicts — pass straight through and replace the previous value.
+
+        Note: each override produces an independent copy; overriding a variant never
+        mutates the base. See :meth:`instantiate` for how shared sub-configs are built.
 
         Args:
             **overrides: Parameter paths and their new values.
@@ -305,6 +320,12 @@ class Config:
             >>> cfg = Config(Pipeline, model=Config(MyModel, layers=6))
             >>> new_cfg = cfg.override(**{'model.layers': 12})
             >>> new_cfg = cfg.override(model='@my_models.CustomModel')
+
+            >>> # One general config, named variants via .override():
+            >>> single_arm = cfn.Config(build, robot_arm=franka, gripper=robotiq)
+            >>> droid = single_arm.override(robot_arm=franka_droid)
+            >>> sim = single_arm.override(robot_arm=franka_sim, **{'robot_arm.collision_coeff': 2.0})
+            >>> cfn.cli({'droid': droid, 'sim': sim})
         """
         overriden_cfg = self._copy()
         overriden_cfg._override_inplace(**overrides)
@@ -356,6 +377,14 @@ class Config:
     def instantiate(self) -> Any:
         """
         Instatiate the target function with the given arguments and keyword arguments.
+
+        Instantiation semantics: every referenced ``Config`` is instantiated
+        independently — there is no instance memoization or identity sharing. If the
+        same sub-config object is referenced from several slots, it is built once *per
+        slot*, yielding that many distinct instances. To share a single instance across
+        multiple slots, build it inside one config that returns the group as a bundle
+        (e.g. a dataclass or dict), and reference that bundle, rather than referencing
+        the same sub-config from each slot.
 
         Returns:
             The instantiated target function.

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -29,6 +29,24 @@ def _to_dict(obj):
         return obj
 
 
+def _copy_value(value):
+    """Recursively copy a config value so variants don't share mutable state.
+
+    Nested ``Config`` instances are copied; ``dict``/``list``/``tuple`` containers are
+    rebuilt so overriding through them (e.g. ``cameras.left.fps``) never mutates the
+    base. Other values (ints, strings, arbitrary objects) are shared by reference —
+    overrides replace them rather than mutate them in place.
+    """
+    if isinstance(value, Config):
+        return value._copy()
+    elif isinstance(value, dict):
+        return {k: _copy_value(v) for k, v in value.items()}
+    elif isinstance(value, list | tuple):
+        return type(value)(_copy_value(v) for v in value)
+    else:
+        return value
+
+
 def _determine_module_by_path(path: str) -> tuple[str, str]:
     module_path = path.split('.')
     object_path = deque([])
@@ -304,10 +322,9 @@ class Config:
         - concrete (non-``Config``) values — ints, floats, objects, ``Config`` instances,
           lists, dicts — pass straight through and replace the previous value.
 
-        Note: overrides apply to a copy, so changing top-level args or nested ``Config``
-        values leaves the base untouched. Plain ``dict``/``list``/``tuple`` arguments are
-        shared with the base, though — a dotted override reaching *through* a container
-        (e.g. ``"cameras.left.fps"``) can mutate it; replace the whole container instead.
+        Note: overrides apply to an independent copy, so a variant never mutates the
+        base — even for dotted overrides that reach through ``dict``/``list``/``tuple``
+        containers (e.g. ``"cameras.left.fps"``), which are copied too.
 
         Args:
             **overrides: Parameter paths and their new values.
@@ -461,9 +478,9 @@ class Config:
         Recursively copy config signatures.
         """
 
-        new_args = [arg._copy() if isinstance(arg, Config) else arg for arg in self.args]
+        new_args = [_copy_value(arg) for arg in self.args]
 
-        new_kwargs = {key: value._copy() if isinstance(value, Config) else value for key, value in self.kwargs.items()}
+        new_kwargs = {key: _copy_value(value) for key, value in self.kwargs.items()}
 
         cfg = Config(self.target)
         cfg.args = new_args

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -378,13 +378,13 @@ class Config:
         """
         Instatiate the target function with the given arguments and keyword arguments.
 
-        Instantiation semantics: every referenced ``Config`` is instantiated
-        independently — there is no instance memoization or identity sharing. If the
-        same sub-config object is referenced from several slots, it is built once *per
-        slot*, yielding that many distinct instances. To share a single instance across
-        multiple slots, build it inside one config that returns the group as a bundle
-        (e.g. a dataclass or dict), and reference that bundle, rather than referencing
-        the same sub-config from each slot.
+        Instantiation semantics: every referenced ``Config`` is built independently —
+        configuronic does not cache or reuse instances. If the same sub-config appears
+        in more than one place, each place gets its own freshly-built object. This
+        matters only when you intend several components to share one object (e.g. a
+        single connection or session): to do that, create the object once inside a
+        single config function and pass it to everyone that needs it, instead of
+        referencing the same sub-config from each slot.
 
         Returns:
             The instantiated target function.

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -294,9 +294,9 @@ class Config:
         rather than writing several near-duplicate config functions. Pass a dict of such
         variants to :func:`configuronic.cli` to expose them as CLI commands.
 
-        Keys may be nested using dot notation to reach into sub-configs and into
-        list/dict slots (e.g. ``"model.layers"``, ``"robot_arm.collision_coeff"``,
-        ``"cameras.left.fps"``, ``"loaders.0.fps"``).
+        Keys may be nested using dot notation to reach into sub-configs (e.g.
+        ``"model.layers"``, ``"robot_arm.collision_coeff"``) and into list/dict slots
+        (e.g. ``"cameras.left"``, ``"loaders.0"``).
 
         Values are resolved by type:
         - strings may use absolute imports (``@module.path.Object``) or relative
@@ -304,8 +304,10 @@ class Config:
         - concrete (non-``Config``) values — ints, floats, objects, ``Config`` instances,
           lists, dicts — pass straight through and replace the previous value.
 
-        Note: each override produces an independent copy; overriding a variant never
-        mutates the base. See :meth:`instantiate` for how shared sub-configs are built.
+        Note: overrides apply to a copy, so changing top-level args or nested ``Config``
+        values leaves the base untouched. Plain ``dict``/``list``/``tuple`` arguments are
+        shared with the base, though — a dotted override reaching *through* a container
+        (e.g. ``"cameras.left.fps"``) can mutate it; replace the whole container instead.
 
         Args:
             **overrides: Parameter paths and their new values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.5.0"
+version = "0.6.0"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.6.0"
+version = "0.5.0"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,6 +374,25 @@ def test_cli_default_command_help_lists_commands_and_flags_default(capfd):
         assert 'python script.py sim --x=<REQUIRED> # Run in simulation' in out
 
 
+def test_cli_default_command_help_with_overrides_reflects_them(capfd):
+    """`--flag --help` on a default command applies the override before printing help,
+    mirroring the leaf path — so an overridden arg is no longer reported as required."""
+
+    @cfn.config()
+    def default_func(a, b):
+        print(f'{a} {b}')
+
+    @cfn.config()
+    def sim(x):
+        print(f'sim: {x}')
+
+    with patch('sys.argv', ['script.py', '--a=1', '--help']):
+        cfn.cli({'': default_func, 'sim': sim})
+        out, err = capfd.readouterr()
+        assert 'b: <REQUIRED>' in out
+        assert 'a: <REQUIRED>' not in out
+
+
 def test_cli_default_command_in_nested_group(capfd):
     """A default command works at an intermediate group node too."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,6 +283,115 @@ def test_cli_leaf_help_reflects_overrides(capfd):
         assert 'a: <REQUIRED>' not in out
 
 
+def test_cli_default_command_runs_with_no_args(capfd):
+    """An '' key is the default command, run when no command is named."""
+
+    @cfn.config(a=7)
+    def default_func(a):
+        print(f'default: {a}')
+
+    @cfn.config()
+    def sim(x):
+        print(f'sim: {x}')
+
+    with patch('sys.argv', ['script.py']):
+        cfn.cli({'': default_func, 'sim': sim})
+        out, err = capfd.readouterr()
+        assert out == 'default: 7\n'
+
+
+def test_cli_default_command_runs_with_leading_option(capfd):
+    """A leading option (no command word) dispatches to the default command and
+    passes the option as an override."""
+
+    @cfn.config(a=7)
+    def default_func(a):
+        print(f'default: {a}')
+
+    @cfn.config()
+    def sim(x):
+        print(f'sim: {x}')
+
+    with patch('sys.argv', ['script.py', '--a=42']):
+        cfn.cli({'': default_func, 'sim': sim})
+        out, err = capfd.readouterr()
+        assert out == 'default: 42\n'
+
+
+def test_cli_default_command_named_command_still_dispatches(capfd):
+    """A known command word is unaffected by the presence of a default command."""
+
+    @cfn.config(a=7)
+    def default_func(a):
+        print(f'default: {a}')
+
+    @cfn.config()
+    def sim(x):
+        print(f'sim: {x}')
+
+    with patch('sys.argv', ['script.py', 'sim', '--x=1']):
+        cfn.cli({'': default_func, 'sim': sim})
+        out, err = capfd.readouterr()
+        assert out == 'sim: 1\n'
+
+
+def test_cli_default_command_unknown_word_still_errors(capfd):
+    """A non-option word that isn't a known command errors even with a default
+    command present (no silent fall-through for typos)."""
+
+    @cfn.config(a=7)
+    def default_func(a):
+        print(f'default: {a}')
+
+    @cfn.config()
+    def sim(x):
+        print(f'sim: {x}')
+
+    with patch('sys.argv', ['script.py', 'simm']):
+        with pytest.raises(ValueError) as e:
+            cfn.cli({'': default_func, 'sim': sim})
+        assert "Command 'simm' not found" in str(e.value)
+
+
+def test_cli_default_command_help_lists_commands_and_flags_default(capfd):
+    """`--help` at a group with a default lists the children and flags the default."""
+
+    @cfn.config()
+    def default_func(a):
+        """Run the default path"""
+        print(f'default: {a}')
+
+    @cfn.config()
+    def sim(x):
+        """Run in simulation"""
+        print(f'sim: {x}')
+
+    with patch('sys.argv', ['script.py', '--help']):
+        cfn.cli({'': default_func, 'sim': sim})
+        out, err = capfd.readouterr()
+        assert 'default command' in out
+        assert 'Run the default path' in out
+        assert 'python script.py sim --x=<REQUIRED> # Run in simulation' in out
+
+
+def test_cli_default_command_in_nested_group(capfd):
+    """A default command works at an intermediate group node too."""
+
+    @cfn.config(a=1)
+    def default_func(a):
+        print(f'default: {a}')
+
+    @cfn.config()
+    def add(a, b):
+        print(a + b)
+
+    tree = {'math': {'': default_func, 'add': add}}
+    with patch('sys.argv', ['script.py', 'math', '--a=9']):
+        cfn.cli(tree)
+        out, err = capfd.readouterr()
+        assert out == 'default: 9\n'
+
+
 def test_cli_group_rejects_unknown_option(capfd):
     """An option-looking token before any leaf is selected is a typo, not a help request."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,6 +148,31 @@ def test_override_nested_keeps_original_config():
     assert cfg.kwargs['env2'].kwargs['camera'].kwargs['name'] == 'Luxonis'
 
 
+def test_override_through_dict_keeps_original_config():
+    """Dotted override reaching through a dict must not mutate the base's dict."""
+    cfg = cfn.Config(
+        MultiEnv,
+        env1=cfn.Config(Env, camera={'left': cfn.Config(Camera, name='OpenCV')}),
+    )
+
+    variant = cfg.override(**{'env1.camera.left.name': 'New Camera'})
+
+    assert cfg.kwargs['env1'].kwargs['camera']['left'].kwargs['name'] == 'OpenCV'
+    assert variant.kwargs['env1'].kwargs['camera']['left'].kwargs['name'] == 'New Camera'
+    assert cfg.kwargs['env1'].kwargs['camera'] is not variant.kwargs['env1'].kwargs['camera']
+
+
+def test_override_through_list_keeps_original_config():
+    """Dotted override reaching through a list must not mutate the base's list."""
+    cfg = cfn.Config(Env, camera=[cfn.Config(Camera, name='OpenCV')])
+
+    variant = cfg.override(**{'camera.0.name': 'New Camera'})
+
+    assert cfg.kwargs['camera'][0].kwargs['name'] == 'OpenCV'
+    assert variant.kwargs['camera'][0].kwargs['name'] == 'New Camera'
+    assert cfg.kwargs['camera'] is not variant.kwargs['camera']
+
+
 def test_config_non_callable_target_raises_error():
     # TODO: Another posibility is to return the original object in this case
     non_callable = object()


### PR DESCRIPTION
## Summary
This PR adds support for default commands in `cfn.cli()` via an empty-string (`''`) key, and expands documentation around the core `.override()` pattern for creating config variants. The default command runs when a command-tree group is reached without naming a child (no args or a leading option), while still rejecting unknown command names to catch typos.

Closes #28
Closes #29

## Key Changes

**Default Command Feature (#28):**
- Added `DEFAULT_COMMAND = ''` constant to mark default commands in command trees
- `_cli_command_tree()` dispatches to the default command when a group is reached without a child name, passing remaining tokens as overrides
- A bare `--help` lists the group's children and flags the default; `--flag --help` applies the overrides and shows the default command's help (mirroring the leaf path)
- `_print_group_help()` flags and displays the default command (without the empty name)
- Comprehensive tests: no args, leading options, named commands still work, unknown words still error, help display (incl. with overrides), and nested groups

**Documentation (#29):**
- New README section "Variants via `.override()`": the idiomatic one-general-config + named `.override()` variants pattern, with a concise DRY rationale for preferring it over near-duplicate config functions
- New README section "Instantiation semantics": a config is a closure and each `Config` reference is instantiated independently (no caching); to share one object across components, bind them together by passing it as a single argument
- Expanded the `Config.override()`, `Config.instantiate()`, and `cli()` docstrings
- Updated the multi-config Best Practices example to use `cfn.cli(dict)` with a default command instead of manual `sys.argv` dispatch

**Bug fix (from review):**
- `override()` / `copy()` now produce a fully independent config. Previously only top-level `Config` kwargs were copied, so a dotted override reaching through a shared `dict`/`list`/`tuple` (e.g. `base.override(**{'cameras.left.fps': 60})`) mutated the base and sibling variants. Nested `Config`s inside containers are now copied too, with regression tests.

**Version & Changelog:**
- Folded into the still-unreleased `0.5.0` (latest published release is v0.4.0); version stays `0.5.0` and the changelog entry covers the new feature, the fix, and the docs.

https://claude.ai/code/session_017gkcSezzV2YsDcrxWk5Gdy