### PR TITLE
Fix shared Config mutation when dotted override descends into a value set in the same call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.5.1] - 2026-07-08
 
 ### Fixed
-- Overriding with a `Config` (or a container of `Config`s) as a value no longer lets a dotted key in the *same* call mutate the shared instance (#31). Previously `cfg.override(codec=shared_codec, **{'codec.flip': True})` (and the equivalent `Config.__init__` / decorator form) wrote `flip=True` onto `shared_codec` itself, silently changing every other config referencing it. `Config` and container override values are now copied on store, so dotted writes always land on a private copy.
+- Overriding with a `Config` (or a container of `Config`s) as a value no longer lets a dotted key in the *same* call mutate the shared instance (#31). Previously `cfg.override(codec=shared_codec, **{'codec.flip': True})` (and the equivalent `Config.__init__` / decorator form, including positional values as in `Config(Env, shared_codec, **{'0.flip': True})`) wrote `flip=True` onto `shared_codec` itself, silently changing every other config referencing it. `Config` and container values are now copied on store — for both keyword and positional arguments — so dotted writes always land on a private copy.
 
 ## [0.5.0] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.1] - 2026-07-08
 
 ### Fixed
 - Overriding with a `Config` (or a container of `Config`s) as a value no longer lets a dotted key in the *same* call mutate the shared instance (#31). Previously `cfg.override(codec=shared_codec, **{'codec.flip': True})` (and the equivalent `Config.__init__` / decorator form) wrote `flip=True` onto `shared_codec` itself, silently changing every other config referencing it. `Config` and container override values are now copied on store, so dotted writes always land on a private copy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Overriding with a `Config` (or a container of `Config`s) as a value no longer lets a dotted key in the *same* call mutate the shared instance (#31). Previously `cfg.override(codec=shared_codec, **{'codec.flip': True})` (and the equivalent `Config.__init__` / decorator form) wrote `flip=True` onto `shared_codec` itself, silently changing every other config referencing it. `Config` and container override values are now copied on store, so dotted writes always land on a private copy.
+
 ## [0.5.0] - 2026-06-09
 
 ### Added

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -297,7 +297,10 @@ class Config:
         """
         assert callable(target), f'Target must be callable, got object of type {type(target)}.'
         self.target = target
-        self.args = [_resolve_value(arg) for arg in args]  # TODO: cover argument override with tests
+        # Copy Config/container args on store (mirroring _set_value) so a numeric dotted keyword
+        # override in the same call (e.g. Config(Env, shared, **{'0.name': ...})) lands on a private
+        # copy rather than mutating a shared positional value. See issue #31.
+        self.args = [_copy_value(_resolve_value(arg)) for arg in args]
         self.kwargs = {}
         self._override_inplace(**kwargs)
 

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -229,12 +229,12 @@ def _set_value(obj, key, value):
     elif isinstance(obj, list):
         index = int(key)
         default = obj[index] if 0 <= index < len(obj) else None
-        obj[index] = _resolve_value(value, default)
+        obj[index] = _copy_value(_resolve_value(value, default))
     elif isinstance(obj, tuple):
         raise NotImplementedError('Overriding tuple values is not implemented')
     elif isinstance(obj, dict):
         default = obj.get(key) if isinstance(obj, dict) else None
-        obj[key] = _resolve_value(value, default)
+        obj[key] = _copy_value(_resolve_value(value, default))
     else:
         raise ConfigError(f'Cannot set value of {obj} with key {key}')
 
@@ -324,7 +324,11 @@ class Config:
 
         Note: overrides apply to an independent copy, so a variant never mutates the
         base — even for dotted overrides that reach through ``dict``/``list``/``tuple``
-        containers (e.g. ``"cameras.left.fps"``), which are copied too.
+        containers (e.g. ``"cameras.left.fps"``), which are copied too. This also holds
+        for ``Config`` (and container) values passed *as* overrides in the same call: a
+        dotted key that descends into such a value (e.g. ``robot_arm=franka_sim`` together
+        with ``"robot_arm.collision_coeff"``) lands on a private copy, never the shared
+        instance.
 
         Args:
             **overrides: Parameter paths and their new values.
@@ -374,7 +378,10 @@ class Config:
 
     def _set_value(self, key, value):
         default = self._get_value(key) if self._has_value(key) else None
-        value = _resolve_value(value, default, config=self)
+        # Copy Config/container values on store (mirroring _copy_value for the base) so that a
+        # dotted override descending into a value set in the same call lands on a private copy
+        # rather than mutating a shared instance. See issue #31.
+        value = _copy_value(_resolve_value(value, default, config=self))
 
         if key[0].isdigit():
             self.args[int(key)] = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.5.0"
+version = "0.5.1"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,6 +210,34 @@ def test_override_container_value_with_dotted_key_keeps_shared_config():
     assert shared_camera.kwargs['name'] == 'OpenCV', 'shared Config inside container was mutated'
 
 
+def test_init_positional_config_value_with_dotted_key_keeps_shared_config():
+    """A Config passed positionally must not be mutated by a numeric dotted key in the same call.
+
+    Regression for issue #31: __init__ stores ``*args`` directly before applying keyword
+    overrides, so ``{'0.name': ...}`` would descend into the shared positional Config.
+    """
+    shared = cfn.Config(Camera, name='OpenCV')
+
+    env = cfn.Config(Env, shared, **{'0.name': 'New Camera'})
+
+    assert env.args[0].kwargs['name'] == 'New Camera'
+    assert shared.kwargs['name'] == 'OpenCV', 'shared positional Config was mutated during __init__'
+
+
+def test_init_positional_container_value_with_dotted_key_keeps_shared_config():
+    """A Config inside a positional container must be copied on store too."""
+
+    def take_list(cameras):
+        return cameras
+
+    shared = cfn.Config(Camera, name='OpenCV')
+
+    cfg = cfn.Config(take_list, [shared], **{'0.0.name': 'New Camera'})
+
+    assert cfg.args[0][0].kwargs['name'] == 'New Camera'
+    assert shared.kwargs['name'] == 'OpenCV', 'shared Config inside positional container was mutated'
+
+
 def test_config_non_callable_target_raises_error():
     # TODO: Another posibility is to return the original object in this case
     non_callable = object()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,6 +173,43 @@ def test_override_through_list_keeps_original_config():
     assert cfg.kwargs['camera'] is not variant.kwargs['camera']
 
 
+def test_override_config_value_with_dotted_key_keeps_shared_config():
+    """A Config passed as an override value must not be mutated by a dotted key in the same call.
+
+    Regression test for issue #31: ``codec=codec`` stores the shared reference and a
+    later ``codec.flip`` write would descend into it, mutating the shared instance.
+    """
+    codec = cfn.Config(Camera, name='OpenCV')
+    server = cfn.Config(Env, camera=cfn.Config(Camera, name='Default'))
+
+    variant = server.override(camera=codec, **{'camera.name': 'New Camera'})
+
+    assert variant.kwargs['camera'].kwargs['name'] == 'New Camera'
+    assert codec.kwargs['name'] == 'OpenCV', 'shared Config was mutated'
+    assert variant.kwargs['camera'] is not codec
+
+
+def test_init_config_value_with_dotted_key_keeps_shared_config():
+    """The decorator/__init__ path funnels through the same code path and must be safe too."""
+    codec = cfn.Config(Camera, name='OpenCV')
+
+    server = cfn.Config(Env, camera=codec, **{'camera.name': 'New Camera'})
+
+    assert server.kwargs['camera'].kwargs['name'] == 'New Camera'
+    assert codec.kwargs['name'] == 'OpenCV', 'shared Config was mutated during __init__'
+
+
+def test_override_container_value_with_dotted_key_keeps_shared_config():
+    """A container of Configs passed as an override value must be copied on store too."""
+    shared_camera = cfn.Config(Camera, name='OpenCV')
+    cfg = cfn.Config(Env, camera=[cfn.Config(Camera, name='Default')])
+
+    variant = cfg.override(camera=[shared_camera], **{'camera.0.name': 'New Camera'})
+
+    assert variant.kwargs['camera'][0].kwargs['name'] == 'New Camera'
+    assert shared_camera.kwargs['name'] == 'OpenCV', 'shared Config inside container was mutated'
+
+
 def test_config_non_callable_target_raises_error():
     # TODO: Another posibility is to return the original object in this case
     non_callable = object()


### PR DESCRIPTION
A Config (or container of Configs) passed as an override value was stored by
reference, so a dotted key reaching into it in the same override()/__init__
call mutated the shared instance in place (issue #31). Copy Config and
container values on store in both _set_value paths, mirroring _copy_value's
treatment of the base, so dotted writes always land on a private copy.

Also fixes the override() docstring note that previously implied the shared
pattern was safe, and adds regression tests for the override, __init__, and
container-value cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W3RyFrZV51MdoMjkmBmd3t