### PR TITLE
Add py.typed marker (PEP 561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.2] - 2026-07-24
+
+### Added
+- PEP 561 `py.typed` marker, declared as package-data so it ships in the sdist and wheel (#34). Downstream type-checkers now read configuronic's inline annotations instead of treating the package as untyped — e.g. `.override(...)` on a `@cfn.config`-decorated symbol resolves correctly rather than being flagged as an unknown member.
+
 ## [0.5.1] - 2026-07-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.5.1"
+version = "0.5.2"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ Issues = "https://github.com/Positronic-Robotics/configuronic/issues"
 where = ["."]
 include = ["configuronic*"]
 
+[tool.setuptools.package-data]
+configuronic = ["py.typed"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"


### PR DESCRIPTION
## What

Ship an empty PEP 561 `configuronic/py.typed` marker, and declare it as `package-data` so it's included in both the sdist and the installed package.

## Why

Without the marker, downstream type-checkers (mypy, basedpyright, pyright) treat `configuronic` as **untyped** and skip its inline annotations entirely. The visible symptom: a `@cfn.config`-decorated symbol's `.override(...)` resolves to nothing, so strict checkers false-flag it (`reportFunctionMemberAccess` / attr-defined). With the marker present, checkers read configuronic's real annotations.

## Risk

- **Runtime: zero.** `py.typed` is inert metadata — never imported or executed.
- **Client-side: opt-in and non-breaking.** The only effect is at type-check time. A downstream running a strict checker could surface new type-check warnings if configuronic's own annotations have gaps, but never a runtime change, and only if they type-check against it.

## Verification

Built both distributions locally; `configuronic/py.typed` is present in each (sdist and wheel). Repo pre-commit (ruff + hygiene) passes on the changed files.

<!-- opened-by: posi-agent -->