### PR TITLE
Fix release-asset attach: grant `contents: write` to the attach job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
     name: Attach to release
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     if: github.event_name == 'release' && github.event.action == 'created'
 
     steps:


### PR DESCRIPTION
## What

Add a least-privilege `permissions: contents: write` to the `attach-to-release` job in `release.yml`.

## Why

The `attach-to-release` job uploads the built sdist to the GitHub Release page via `softprops/action-gh-release`, which calls the releases API. The workflow declares no `permissions:` block, so under the repo's default read-only `GITHUB_TOKEN` that API call fails with:

```
Unexpected error fetching GitHub release for tag refs/tags/vX.Y.Z:
HttpError: Resource not accessible by integration
```

Result: the sdist is never attached to the Release page — observed on both **v0.5.1** and **v0.5.2** (both show empty release assets). The failure is silent to the release cutter because it's a separate job from publish.

## Scope / risk

- Grants `contents: write` to the **attach job only** (least privilege), not workflow-wide.
- **PyPI publish is unaffected** — that job authenticates with `PYPI_API_TOKEN`, not `GITHUB_TOKEN`, which is why 0.5.2 published to PyPI fine despite this bug.
- No functional change to build or publish; only the Release-page asset attach is repaired.
