### PR TITLE
Add override_data() for safe handling of untrusted override values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.6.0] - 2026-07-25
+
+### Added
+- `Config.override_data()`, for applying overrides whose values come from outside the process — a request, a URL, a user-supplied file (#36). Same dotted overrides as `override()`, but values are interpreted strictly as data: a string that `override()` would resolve as an import raises `ImportNotAllowedError` instead, at any nesting depth. This covers the relative (`.`) form as seriously as the absolute (`@`) one — leading dots walk *up* the module tree, and enough of them leave the package entirely. Values that are not import references pass through untouched.
+- `ImportNotAllowedError` (a `ConfigError`), carrying the offending `key` (the full dotted path, e.g. `cameras[0]`) and `value`, so a server can name the refused parameter back to the caller.
+
+### Fixed
+- Override failures now report the full dotted key. Previously `cfg.override(**{'arg.a.b': 4})` reported `Failed to override 'a'` — an intermediate segment — instead of `Failed to override 'arg.a.b'`.
+
 ## [0.5.2] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -438,6 +438,58 @@ To pass literal strings starting with `.` (like `'./data'` or `'.env'`), use ind
 python script.py --paths='["",""]' --paths.0='./data' --paths.1='.env'
 ```
 
+### Overrides From an Untrusted Source
+
+`override()` resolves import strings, so an override value is as trusted as your own code:
+`--model="@my_models.Custom"` is a feature on your CLI, but `codec="@os.system"` coming off
+the network is arbitrary code execution. When the *values* come from outside the process —
+a request, a URL, a user-supplied file — use **`override_data()`** instead. It applies the
+same dotted overrides with values interpreted strictly as data: import strings are refused,
+not resolved.
+
+```python
+# params decoded from a request, a URL, a user-supplied file
+session_cfg = policy_cfg.override_data(**params)   # tunes arguments, cannot swap components
+
+policy_cfg.override_data(codec='@os.system')       # ImportNotAllowedError
+policy_cfg.override_data(codec='....os.system')    # ImportNotAllowedError
+```
+
+Both forms are refused, at any nesting depth (inside lists and dicts too). The relative
+form matters as much as the absolute one: leading dots walk *up* the module tree from the
+current value's module, and enough of them leave the package entirely — the dot count is
+just the depth of that module, which is not a secret.
+
+`ImportNotAllowedError` (a `ConfigError`) carries the offending `key` and `value`, so a
+server can tell the caller exactly which parameter was refused:
+
+```python
+try:
+    session_cfg = policy_cfg.override_data(**params)
+except cfn.ImportNotAllowedError as e:
+    raise BadRequest(f'parameter {e.key!r}: {e.value!r} is not a plain value')
+```
+
+Strings starting with `@` are refused whole, including `override()`'s `'@@x'` escape for a
+literal `'@x'`: a stored `'@...'` string is itself a valid base for a later relative
+override, so accepting one would let the caller choose the path a subsequent trusted
+override resolves against.
+
+Everything else behaves exactly like `override()` — same dotted keys, same copy-on-write
+semantics, and values that aren't import references are untouched: `'./data'` stays a
+literal string wherever it would be one for `override()`. Inside a list or dict, that means
+nowhere — every leading-dot string in a container resolves against the config (a documented
+0.3.0 rule that `override_data` inherits rather than diverges from), so pass such values
+with indexed keys, exactly as you would to `override()`:
+
+```python
+policy_cfg.override_data(paths=['./data'])          # ImportNotAllowedError
+policy_cfg.override_data(**{'paths.0': './data'})   # fine
+```
+
+The restriction is on strings, the only thing external data can carry; your own code can
+still pass a `Config` as a value.
+
 ### Configuration Inheritance
 
 ```python
@@ -572,6 +624,7 @@ Main configuration class that stores a callable and its arguments.
 
 **Methods:**
 - `override(**kwargs) -> Config`: Create new config with updated parameters
+- `override_data(**kwargs) -> Config`: Same, but values are interpreted strictly as data — import strings (`@…`, `.…`) raise `ImportNotAllowedError` instead of being resolved. Use it when the values come from outside the process.
 - `instantiate() -> Any`: Execute the configuration and return result
 - `copy() -> Config`: Deep copy the configuration
 - `__call__(**kwargs) -> Any`: `override` config with `**kwargs` and `instantiate` it. **Note:** only keyword specified arguments are supported.
@@ -609,6 +662,11 @@ cfn.cli({'': train_config, 'eval': eval_config})
 
 #### `get_required_args(config: Config) -> List[str]`
 Get list of required arguments for a configuration.
+
+### Exceptions
+
+- `ConfigError` - Raised when an override path is invalid or a config cannot be built
+- `ImportNotAllowedError` - Subclass of `ConfigError`, raised by `override_data` when a value uses import syntax. Carries the offending `key` and `value`
 
 ### Special Syntax
 

--- a/configuronic/__init__.py
+++ b/configuronic/__init__.py
@@ -1,4 +1,4 @@
 from .cli import cli, get_required_args
-from .config import Config, ConfigError, config
+from .config import Config, ConfigError, ImportNotAllowedError, config
 
-__all__ = ['config', 'Config', 'ConfigError', 'cli', 'get_required_args']
+__all__ = ['config', 'Config', 'ConfigError', 'ImportNotAllowedError', 'cli', 'get_required_args']

--- a/configuronic/config.py
+++ b/configuronic/config.py
@@ -18,6 +18,35 @@ class ConfigError(Exception):
     pass
 
 
+class ImportNotAllowedError(ConfigError):
+    """Raised when an override value uses import syntax where imports are not allowed.
+
+    Raised by :meth:`Config.override_data`, which applies overrides with values
+    interpreted strictly as data. The offending key and value are available as
+    attributes so a caller can report them back to whoever supplied the value.
+
+    Attributes:
+        key: Dotted path of the rejected override. Values nested inside a list or dict
+            carry their position, e.g. ``cameras[0]`` or ``codecs['left']``.
+        value: The rejected string value.
+    """
+
+    def __init__(self, key: str, value: str):
+        self.key = key
+        self.value = value
+        super().__init__(
+            f"Override '{key}' has value {value!r}, which configuronic would read as import syntax: a leading "
+            f"'{INSTANTIATE_PREFIX}' (absolute) or '{RELATIVE_PATH_PREFIX}' (relative to the current value) names a "
+            'Python object to import. This override accepts plain data only.'
+        )
+
+    def __reduce__(self):
+        # Exception.__reduce__ rebuilds from `args`, which holds only the formatted message,
+        # so the default would call __init__ with one argument. Servers pickle exceptions
+        # back from worker processes, so keep the two-argument form reconstructible.
+        return (self.__class__, (self.key, self.value))
+
+
 def _to_dict(obj):
     if isinstance(obj, Config):
         return obj._to_dict()
@@ -175,7 +204,13 @@ def _can_resolve_relative(default: Any | None) -> bool:
     return False
 
 
-def _resolve_value(value: Any, default: Any | None = None, config: Config | None = None) -> Any:
+def _resolve_value(
+    value: Any,
+    default: Any | None = None,
+    config: Config | None = None,
+    resolve_imports: bool = True,
+    key: str = '',
+) -> Any:
     """Resolve special strings to actual Python objects.
 
     Supports two prefixes:
@@ -189,23 +224,44 @@ def _resolve_value(value: Any, default: Any | None = None, config: Config | None
     For lists and dicts:
     - Both absolute (``@``) and relative (``.``) references are resolved recursively at all nesting levels
     - Nested collections inherit the same resolution context from their parent
+
+    When ``resolve_imports`` is False, every value that *would* have been resolved as an
+    import raises :class:`ImportNotAllowedError` instead — at any nesting depth. Values
+    that are not import references (including leading-dot strings with no base to resolve
+    against, such as ``./data``) are returned unchanged, exactly as they would be with
+    ``resolve_imports=True``. ``key`` is the location reported in that error; callers
+    prepend the override key they were given.
     """
     if isinstance(value, str):
         if value.startswith(INSTANTIATE_PREFIX):
-            if value[len(INSTANTIATE_PREFIX) :].startswith(INSTANTIATE_PREFIX):
+            if not resolve_imports:
+                # Refused *before* the '@@' escape is applied. An escaped value is stored as a
+                # literal '@...' string, and `_can_resolve_relative` accepts any such string as
+                # an import base — so a later trusted relative override on the same key would
+                # resolve against a path this caller chose. Storing one is planting an import.
+                raise ImportNotAllowedError(key, value)
+            elif value[len(INSTANTIATE_PREFIX) :].startswith(INSTANTIATE_PREFIX):
                 return value[len(INSTANTIATE_PREFIX) :]
             else:
                 return _import_object_from_path(value)
         # Only resolve relative imports when `default` provides a valid base.
         # Treat all other leading-dot strings as literals (e.g., '../data', '.env').
         elif value.startswith(RELATIVE_PATH_PREFIX) and _can_resolve_relative(default):
+            if not resolve_imports:
+                raise ImportNotAllowedError(key, value)
             return _resolve_relative_import(value, default)
         else:
             return value
     elif isinstance(value, list | tuple):
-        return type(value)(_resolve_value(item, default=config, config=config) for item in value)
+        return type(value)(
+            _resolve_value(item, default=config, config=config, resolve_imports=resolve_imports, key=f'{key}[{i}]')
+            for i, item in enumerate(value)
+        )
     elif isinstance(value, dict):
-        return {k: _resolve_value(v, default=config, config=config) for k, v in value.items()}
+        return {
+            k: _resolve_value(v, default=config, config=config, resolve_imports=resolve_imports, key=f'{key}[{k!r}]')
+            for k, v in value.items()
+        }
     else:
         return value
 
@@ -223,18 +279,18 @@ def _get_value(obj, key):
         raise ConfigError(f'Cannot get value of {obj} with key {key}')
 
 
-def _set_value(obj, key, value):
+def _set_value(obj, key, value, resolve_imports: bool = True):
     if isinstance(obj, Config):
-        obj._set_value(key, value)
+        obj._set_value(key, value, resolve_imports=resolve_imports)
     elif isinstance(obj, list):
         index = int(key)
         default = obj[index] if 0 <= index < len(obj) else None
-        obj[index] = _copy_value(_resolve_value(value, default))
+        obj[index] = _copy_value(_resolve_value(value, default, resolve_imports=resolve_imports))
     elif isinstance(obj, tuple):
         raise NotImplementedError('Overriding tuple values is not implemented')
     elif isinstance(obj, dict):
         default = obj.get(key) if isinstance(obj, dict) else None
-        obj[key] = _copy_value(_resolve_value(value, default))
+        obj[key] = _copy_value(_resolve_value(value, default, resolve_imports=resolve_imports))
     else:
         raise ConfigError(f'Cannot set value of {obj} with key {key}')
 
@@ -302,7 +358,7 @@ class Config:
         # copy rather than mutating a shared positional value. See issue #31.
         self.args = [_copy_value(_resolve_value(arg)) for arg in args]
         self.kwargs = {}
-        self._override_inplace(**kwargs)
+        self._override_inplace(kwargs)
 
         self._creator_module = _get_creator_module()
 
@@ -324,6 +380,11 @@ class Config:
           imports (``.SiblingObject``);
         - concrete (non-``Config``) values — ints, floats, objects, ``Config`` instances,
           lists, dicts — pass straight through and replace the previous value.
+
+        Because import strings are resolved, an override value is as trusted as your own
+        code: it can name any importable object. When the values come from outside the
+        process (a request, a URL, a user-supplied file), use :meth:`override_data`
+        instead, which refuses import strings rather than resolving them.
 
         Note: overrides apply to an independent copy, so a variant never mutates the
         base — even for dotted overrides that reach through ``dict``/``list``/``tuple``
@@ -354,7 +415,7 @@ class Config:
             >>> cfn.cli({'droid': droid, 'sim': sim})
         """
         overriden_cfg = self._copy()
-        overriden_cfg._override_inplace(**overrides)
+        overriden_cfg._override_inplace(overrides)
         # we want to keep creator module (module override was called from) for the overriden config
         # But we override it after the overrides are applied, so that lists and dicts arguments
         # are resolved relative to the original config, not the overriden config.
@@ -362,29 +423,89 @@ class Config:
 
         return overriden_cfg
 
-    def _override_inplace(self, **overrides):
+    def override_data(self, **overrides) -> Config:
+        """
+        Like :meth:`override`, but values are interpreted strictly as data.
+
+        Use this when the override *values* come from outside the process — a network
+        request, a URL query string, a user-supplied file. :meth:`override` treats a string
+        starting with ``@`` or ``.`` as an object to import, which is right for overrides
+        written by your own code but turns a config knob into arbitrary code execution when
+        the value comes from a caller you do not control. ``override_data`` refuses those
+        strings instead of resolving them, so an untrusted caller can tune arguments but
+        never swap components.
+
+        Both forms are refused, at any nesting depth (inside lists and dicts too):
+
+        - absolute — ``'@os.system'``;
+        - relative — ``'....os.system'``. The relative form is no safer than the absolute
+          one: leading dots walk *up* the module tree from the current value's module, and
+          enough of them leave the package entirely.
+
+        Strings starting with ``@`` are refused whole, including the ``'@@x'`` escape that
+        :meth:`override` reads as the literal ``'@x'``: a stored ``'@...'`` string is itself
+        a valid base for a later relative override, so accepting one would let this caller
+        choose the path a subsequent trusted override resolves against.
+
+        Everything else behaves exactly like :meth:`override` — same dotted keys, same
+        copy-on-write semantics, same treatment of values that are not import references
+        (a leading-dot string with no config to resolve against, e.g. ``'./data'``, stays a
+        literal string here just as it does there).
+
+        Note this constrains values, not the caller: passing a ``Config`` (or any other
+        Python object) as a value still works, since only your own code can do that. It is
+        strings — the only thing external data can carry — that never become imports.
+
+        Args:
+            **overrides: Parameter paths and their new values.
+
+        Returns:
+            Config: A new Config with overridden parameters.
+
+        Raises:
+            ImportNotAllowedError: If a value (or a value nested in a list/dict) is an
+                import reference. The offending key and value are on the exception, for
+                reporting back to whoever supplied them.
+            ConfigError: If a parameter path is invalid.
+
+        Example:
+            >>> params = {'codec.fps': 10}  # decoded from a request, a URL, a file
+            >>> cfg = policy.override_data(**params)  # raises on {'codec': '@os.system'}
+        """
+        overriden_cfg = self._copy()
+        overriden_cfg._override_inplace(overrides, resolve_imports=False)
+        overriden_cfg._creator_module = _get_creator_module()
+
+        return overriden_cfg
+
+    def _override_inplace(self, overrides: dict[str, Any], resolve_imports: bool = True):
         for key, value in overrides.items():
             try:
                 key_list = key.split('.')
 
                 current_obj = self
 
-                for i, key in enumerate(key_list[:-1]):
-                    current_obj = _get_value(current_obj, key)
+                for i, part in enumerate(key_list[:-1]):
+                    current_obj = _get_value(current_obj, part)
                     if current_obj is None:
                         path_to_not_found_arg = '.'.join(key_list[: i + 1])
                         raise ConfigError(f"Argument '{path_to_not_found_arg}' not found in config")
 
-                _set_value(current_obj, key_list[-1], value)
+                _set_value(current_obj, key_list[-1], value, resolve_imports=resolve_imports)
+            except ImportNotAllowedError as e:
+                # Re-raise (rather than wrap) so callers can tell "you tried to sneak in an import"
+                # apart from any other override failure. `e.key` holds the position inside the
+                # value (for containers); the override key it belongs to is only known here.
+                raise ImportNotAllowedError(f'{key}{e.key}', e.value) from None
             except Exception as e:
                 raise ConfigError(f"Failed to override '{key}' with value '{value}'") from e
 
-    def _set_value(self, key, value):
+    def _set_value(self, key, value, resolve_imports: bool = True):
         default = self._get_value(key) if self._has_value(key) else None
         # Copy Config/container values on store (mirroring _copy_value for the base) so that a
         # dotted override descending into a value set in the same call lands on a private copy
         # rather than mutating a shared instance. See issue #31.
-        value = _copy_value(_resolve_value(value, default, config=self))
+        value = _copy_value(_resolve_value(value, default, config=self, resolve_imports=resolve_imports))
 
         if key[0].isdigit():
             self.args[int(key)] = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "configuronic"
-version = "0.5.2"
+version = "0.6.0"
 description = "Simple yet powerful \"Configuration as Code\" library"
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/support_package/import_tripwire.py
+++ b/tests/support_package/import_tripwire.py
@@ -1,0 +1,7 @@
+"""Tripwire module: nothing imports it, so its presence in ``sys.modules`` proves an import happened.
+
+Used by the ``override_data`` tests to show that a rejected import string is refused
+*before* anything is imported, rather than imported and then discarded.
+"""
+
+value = 'tripwire'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -631,7 +631,7 @@ def test_override_nested_error_preserves_original_cause():
     with pytest.raises(cfn.ConfigError) as exc_info:
         env_cfg.override(**{'camera.name.nonexistent': 'value'})
 
-    assert str(exc_info.value) == "Failed to override 'name' with value 'value'"
+    assert str(exc_info.value) == "Failed to override 'camera.name.nonexistent' with value 'value'"
     assert isinstance(exc_info.value.__cause__, cfn.ConfigError)
     assert 'Cannot set value' in str(exc_info.value.__cause__)
 
@@ -961,7 +961,7 @@ def test_override_existing_list_arg_reports_context_for_index_error():
     with pytest.raises(cfn.ConfigError) as exc_info:
         func.override(**{'a.4': 4})
 
-    assert str(exc_info.value) == "Failed to override 'a' with value '4'"
+    assert str(exc_info.value) == "Failed to override 'a.4' with value '4'"
     assert isinstance(exc_info.value.__cause__, IndexError)
     assert 'list assignment index out of range' in str(exc_info.value.__cause__)
 
@@ -974,7 +974,7 @@ def test_override_non_existing_list_arg_raises_config_error():
     with pytest.raises(cfn.ConfigError) as exc_info:
         func.override(**{'b.0': 4})
 
-    assert str(exc_info.value) == "Failed to override 'b' with value '4'"
+    assert str(exc_info.value) == "Failed to override 'b.0' with value '4'"
     assert isinstance(exc_info.value.__cause__, cfn.ConfigError)
     assert "Argument 'b' not found in config" in str(exc_info.value.__cause__)
 
@@ -1005,7 +1005,7 @@ def test_override_non_existing_nested_argument_raises_config_error():
     with pytest.raises(cfn.ConfigError) as exc_info:
         composite_obj.override(**{'arg.a.b': 4}).instantiate()
 
-    assert str(exc_info.value) == "Failed to override 'a' with value '4'"
+    assert str(exc_info.value) == "Failed to override 'arg.a.b' with value '4'"
     assert isinstance(exc_info.value.__cause__, cfn.ConfigError)
     assert "Argument 'arg.a' not found in config" in str(exc_info.value.__cause__)
 

--- a/tests/test_untrusted_overrides.py
+++ b/tests/test_untrusted_overrides.py
@@ -1,0 +1,260 @@
+"""Tests for applying overrides whose values come from an untrusted source.
+
+See issue #36: values that come off the network must be able to tune arguments but never
+name an object to import.
+"""
+
+import copy
+import pickle
+import sys
+
+import pytest
+
+import configuronic as cfn
+from tests.support_package.subpkg.a import A
+
+
+class Camera:
+    def __init__(self, name: str = 'default', fps: int = 30):
+        self.name = name
+        self.fps = fps
+
+
+class Env:
+    def __init__(self, camera, path: str = '/data', paths: list | None = None):
+        self.camera = camera
+        self.path = path
+        self.paths = paths
+
+
+def _env_config() -> cfn.Config:
+    return cfn.Config(Env, camera=cfn.Config(Camera))
+
+
+# --- override_data: plain data still works ------------------------------------------------
+
+
+def test_override_data_applies_scalar_override():
+    env = _env_config().override_data(**{'camera.fps': 10})
+
+    assert env.instantiate().camera.fps == 10
+
+
+def test_override_data_applies_container_values():
+    env = _env_config().override_data(paths=['a', 'b'], **{'camera.name': 'left'})
+
+    instance = env.instantiate()
+    assert instance.paths == ['a', 'b']
+    assert instance.camera.name == 'left'
+
+
+def test_override_data_does_not_mutate_base_config():
+    base = _env_config()
+
+    base.override_data(**{'camera.fps': 10})
+
+    assert base.instantiate().camera.fps == 30
+
+
+def test_override_data_accepts_config_value_from_calling_code():
+    # The guarantee constrains *strings* (the only thing external data carries), not the
+    # caller: our own code can still pass a Config as a value.
+    env = _env_config().override_data(camera=cfn.Config(Camera, name='right'))
+
+    assert env.instantiate().camera.name == 'right'
+
+
+def test_override_data_keeps_leading_dot_string_that_is_not_an_import():
+    # 'path' defaults to a plain string, so there is no base to resolve against and
+    # './data' is a literal here — same as with override().
+    env = _env_config().override_data(path='./data')
+
+    assert env.instantiate().path == './data'
+
+
+def test_override_data_keeps_leading_dot_string_in_indexed_override():
+    env = _env_config().override_data(paths=['x', 'y'], **{'paths.0': '../data'})
+
+    assert env.instantiate().paths == ['../data', 'y']
+
+
+def test_override_data_keeps_at_sign_that_does_not_lead():
+    env = _env_config().override_data(path='user@example.com')
+
+    assert env.instantiate().path == 'user@example.com'
+
+
+# --- override_data: import strings are refused --------------------------------------------
+
+
+def test_override_data_rejects_absolute_import():
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(camera='@os.system')
+
+    assert exc_info.value.key == 'camera'
+    assert exc_info.value.value == '@os.system'
+    assert "'camera'" in str(exc_info.value)
+    assert '@os.system' in str(exc_info.value)
+
+
+def test_override_data_rejects_relative_import_escaping_the_package():
+    # A relative override is no safer than an absolute one: leading dots walk up the module
+    # tree from the current value's module and enough of them leave the package. The base
+    # here is this test module, so three dots reach the top level. The override() assertion
+    # is deliberate — if resolution ever stops reaching os.system, this guard test would be
+    # passing for the wrong reason.
+    escape = '...os.system'
+
+    assert _env_config().override(camera=escape).kwargs['camera'] is __import__('os').system
+
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(camera=escape)
+
+    assert exc_info.value.key == 'camera'
+    assert exc_info.value.value == escape
+
+
+def test_override_data_rejects_relative_import_before_importing_anything():
+    tripwire = 'tests.support_package.import_tripwire'
+    assert tripwire not in sys.modules, 'tripwire module must stay unimported for this test to mean anything'
+
+    with pytest.raises(cfn.ImportNotAllowedError):
+        _env_config().override_data(camera='@tests.support_package.import_tripwire.value')
+
+    assert tripwire not in sys.modules
+
+
+def test_override_data_rejects_relative_import_that_would_not_resolve():
+    # Rejection is about the syntax, not about whether the import happens to succeed.
+    with pytest.raises(cfn.ImportNotAllowedError):
+        _env_config().override_data(camera='.NoSuchObject')
+
+
+def test_override_data_reports_full_dotted_key():
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(**{'camera.name': '@os.system'})
+
+    assert exc_info.value.key == 'camera.name'
+
+
+def test_override_data_rejects_import_nested_in_list():
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(paths=['ok', '@os.system'])
+
+    assert exc_info.value.key == 'paths[1]'
+    assert exc_info.value.value == '@os.system'
+
+
+def test_override_data_rejects_import_nested_in_dict():
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(paths={'left': '@os.system'})
+
+    assert exc_info.value.key == "paths['left']"
+
+
+def test_override_data_rejects_import_nested_deeply():
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(paths=[{'left': ['@os.system']}])
+
+    assert exc_info.value.key == "paths[0]['left'][0]"
+
+
+def test_override_data_rejects_relative_import_nested_in_list():
+    # Inside containers every leading-dot string resolves against the config, so the
+    # relative form must be refused there too.
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(paths=['...os.system'])
+
+    assert exc_info.value.key == 'paths[0]'
+
+
+def test_override_data_rejects_import_in_positional_argument():
+    cfg = cfn.Config(Env, cfn.Config(Camera))
+
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        cfg.override_data(**{'0': '@os.system'})
+
+    assert exc_info.value.key == '0'
+
+
+def test_override_data_rejects_escaped_at_prefix():
+    # '@@x' is override()'s escape for the literal '@x'. Storing it would plant an import
+    # base, so override_data refuses it before unescaping.
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(path='@@os.system')
+
+    assert exc_info.value.value == '@@os.system'
+
+
+def test_override_data_cannot_plant_a_base_for_a_later_relative_override():
+    tripwire = 'tests.support_package.import_tripwire'
+    assert tripwire not in sys.modules, 'tripwire module must stay unimported for this test to mean anything'
+    cfg = cfn.Config(Env, camera=cfn.Config(Camera))
+
+    # Were the escape accepted, `camera` would hold the literal '@tests...import_tripwire.x',
+    # which _can_resolve_relative treats as a base — so this later trusted relative override
+    # would import a module the untrusted caller named.
+    with pytest.raises(cfn.ImportNotAllowedError):
+        cfg.override_data(camera=f'@@{tripwire}.x').override(camera='.value')
+
+    assert tripwire not in sys.modules
+
+
+def test_override_data_cannot_plant_a_base_inside_a_container():
+    cfg = cfn.Config(Env, paths=['x'])
+
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        cfg.override_data(**{'paths.0': '@@tests.support_package.cfg.echo'})
+
+    assert exc_info.value.key == 'paths.0'
+
+
+def test_import_not_allowed_error_survives_pickling():
+    # The advertised use case is a server, where the override may run in a worker process
+    # and the exception is pickled back to the request handler.
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(camera='@os.system')
+
+    restored = pickle.loads(pickle.dumps(exc_info.value))
+
+    assert restored.key == 'camera'
+    assert restored.value == '@os.system'
+    assert str(restored) == str(exc_info.value)
+
+
+def test_import_not_allowed_error_survives_copying():
+    with pytest.raises(cfn.ImportNotAllowedError) as exc_info:
+        _env_config().override_data(camera='@os.system')
+
+    assert copy.copy(exc_info.value).key == 'camera'
+    assert copy.deepcopy(exc_info.value).value == '@os.system'
+
+
+def test_override_data_rejection_is_a_config_error():
+    with pytest.raises(cfn.ConfigError):
+        _env_config().override_data(camera='@os.system')
+
+
+def test_override_data_rejection_leaves_base_config_untouched():
+    base = _env_config()
+
+    with pytest.raises(cfn.ImportNotAllowedError):
+        base.override_data(**{'camera.fps': 10, 'camera.name': '@os.system'})
+
+    instance = base.instantiate()
+    assert instance.camera.fps == 30
+    assert instance.camera.name == 'default'
+
+
+def test_override_data_still_reports_unknown_keys():
+    with pytest.raises(cfn.ConfigError) as exc_info:
+        _env_config().override_data(**{'nonexistent.fps': 10})
+
+    assert "Failed to override 'nonexistent.fps'" in str(exc_info.value)
+
+
+def test_override_keeps_resolving_imports():
+    # override() is unchanged: import strings are still resolved there.
+    env = _env_config().override(camera='@tests.support_package.subpkg.a.A')
+
+    assert env.kwargs['camera'] is A


### PR DESCRIPTION
## Summary

Adds `Config.override_data()` method to safely apply configuration overrides when values come from untrusted sources (network requests, user files, etc.). Unlike `override()` which resolves import strings, `override_data()` treats all values strictly as data and raises `ImportNotAllowedError` if any value uses import syntax.

## Key Changes

- **New `override_data()` method**: Applies dotted overrides with `resolve_imports=False`, refusing both absolute (`@module.path`) and relative (`.module.path`) import strings at any nesting depth (lists, dicts, etc.)

- **New `ImportNotAllowedError` exception**: A `ConfigError` subclass that carries the offending `key` (full dotted path including container indices like `cameras[0]`) and `value` for reporting back to the caller. Implements `__reduce__()` for pickle support in server scenarios.

- **Enhanced `_resolve_value()` function**: Added `resolve_imports` parameter (default `True`) and `key` parameter for error reporting. When `resolve_imports=False`, any string that would be resolved as an import raises `ImportNotAllowedError` instead. Non-import strings (like `'./data'` with no base to resolve against) pass through unchanged.

- **Updated `_set_value()` and `Config._set_value()`**: Thread `resolve_imports` parameter through the call chain to control import resolution behavior.

- **Updated `_override_inplace()`**: Accepts `resolve_imports` parameter and catches `ImportNotAllowedError` to re-raise with the full override key path prepended.

- **Comprehensive test suite**: 260 lines of tests covering valid data overrides, rejection of absolute/relative imports at all nesting levels, error reporting, pickling/copying of exceptions, and interaction with trusted `override()`.

## Notable Implementation Details

- Escaped `@@` strings are refused whole (before unescaping) because a stored `'@...'` string becomes a valid base for later relative overrides, allowing an untrusted caller to choose import paths for trusted code.

- Relative imports are refused even when they wouldn't resolve, and before any imports occur, preventing side effects from import machinery.

- Container indices are tracked in error keys (e.g., `paths[0]`, `codecs['left']`) for precise error reporting.

- The restriction applies only to strings; calling code can still pass `Config` objects or other Python types as values.

- Updated version to 0.6.0 and documented the feature in README with security rationale and usage examples.

https://claude.ai/code/session_01JATY7MYjiJPhfLHFcQaqU2